### PR TITLE
feat: endpoint /auth/me retorna perfil completo do banco

### DIFF
--- a/estudos-platform/backend-platform/internal/applications/estudos/usecase/obter_perfil.go
+++ b/estudos-platform/backend-platform/internal/applications/estudos/usecase/obter_perfil.go
@@ -1,0 +1,36 @@
+package usecase
+
+import (
+	"context"
+	stderrors "errors"
+
+	"github.com/thiago-tertuliano/estudos-platform/internal/applications/estudos/dto"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/repository"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+// ObterPerfil busca o usuário completo pelo ID extraído do token autenticado.
+type ObterPerfil struct {
+	repo repository.UsuarioRepository
+}
+
+func NewObterPerfil(repo repository.UsuarioRepository) *ObterPerfil {
+	return &ObterPerfil{repo: repo}
+}
+
+func (uc *ObterPerfil) Execute(ctx context.Context, usuarioID string) (*dto.UsuarioResponse, error) {
+	usuario, err := uc.repo.FindByID(ctx, usuarioID)
+	if err != nil {
+		var de *errors.DomainError
+		if stderrors.As(err, &de) && de.Kind == errors.NotFound {
+			return nil, errors.ErrNotFound("usuário não encontrado", "ObterPerfil.Execute", nil)
+		}
+		return nil, errors.ErrInternal("falha ao buscar usuário", "ObterPerfil.Execute", err)
+	}
+
+	return &dto.UsuarioResponse{
+		ID:    usuario.ID().String(),
+		Nome:  usuario.Nome(),
+		Email: usuario.Email().Value(),
+	}, nil
+}

--- a/estudos-platform/backend-platform/internal/applications/estudos/usecase/obter_perfil_test.go
+++ b/estudos-platform/backend-platform/internal/applications/estudos/usecase/obter_perfil_test.go
@@ -1,0 +1,41 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/entity"
+	domainErros "github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+func TestObterPerfil_Sucesso(t *testing.T) {
+	ctx := context.Background()
+	u := usuarioTeste(t)
+	repo := &MockUsuarioRepository{
+		FindByIDFn: func(ctx context.Context, id string) (*entity.Usuario, error) { return u, nil },
+	}
+	uc := NewObterPerfil(repo)
+
+	resp, err := uc.Execute(ctx, u.ID().String())
+	if err != nil {
+		t.Fatalf("não deveria retornar erro: %v", err)
+	}
+	if resp.ID != u.ID().String() || resp.Nome != "Thiago" || resp.Email != "t@ex.com" {
+		t.Errorf("perfil incorreto: %+v", resp)
+	}
+}
+
+func TestObterPerfil_NaoEncontrado(t *testing.T) {
+	ctx := context.Background()
+	repo := &MockUsuarioRepository{
+		FindByIDFn: func(ctx context.Context, id string) (*entity.Usuario, error) {
+			return nil, domainErros.ErrNotFound("usuário não encontrado", "mock", nil)
+		},
+	}
+	uc := NewObterPerfil(repo)
+
+	_, err := uc.Execute(ctx, "u-inexistente")
+	if de, ok := err.(*domainErros.DomainError); !ok || de.Kind != domainErros.NotFound {
+		t.Errorf("esperava NotFound, got %#v", err)
+	}
+}

--- a/estudos-platform/backend-platform/internal/presentation/http/handler/auth_handler.go
+++ b/estudos-platform/backend-platform/internal/presentation/http/handler/auth_handler.go
@@ -26,19 +26,25 @@ type RefreshUseCase interface {
 	Execute(ctx context.Context, refreshToken string) (*dto.AuthResponse, error)
 }
 
+type ObterPerfilUseCase interface {
+	Execute(ctx context.Context, usuarioID string) (*dto.UsuarioResponse, error)
+}
+
 // AuthHandler é LEVE: só faz binding, validação de borda e delega para o use case.
 type AuthHandler struct {
 	registrar RegistrarUseCase
 	login     LoginUseCase
 	refresh   RefreshUseCase
+	perfil    ObterPerfilUseCase
 	validate  *validator.Validate
 }
 
-func NewAuthHandler(registrar RegistrarUseCase, login LoginUseCase, refresh RefreshUseCase) *AuthHandler {
+func NewAuthHandler(registrar RegistrarUseCase, login LoginUseCase, refresh RefreshUseCase, perfil ObterPerfilUseCase) *AuthHandler {
 	return &AuthHandler{
 		registrar: registrar,
 		login:     login,
 		refresh:   refresh,
+		perfil:    perfil,
 		validate:  validator.New(),
 	}
 }
@@ -82,13 +88,16 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	h.escreverJSON(w, http.StatusOK, resp)
 }
 
-// Me retorna o perfil do usuário logado (dados vêm do token validado no middleware).
+// Me retorna o perfil completo do usuário logado (ID vem do token validado no
+// middleware; nome/email são buscados no banco pelo use case).
 func (h *AuthHandler) Me(w http.ResponseWriter, r *http.Request) {
 	usuarioID, _ := r.Context().Value(middleware.CtxUsuarioID).(string)
-	email, _ := r.Context().Value(middleware.CtxEmail).(string)
-
-	payload := dto.UsuarioResponse{ID: usuarioID, Email: email}
-	h.escreverJSON(w, http.StatusOK, payload)
+	resp, err := h.perfil.Execute(r.Context(), usuarioID)
+	if err != nil {
+		h.escreverErro(w, err)
+		return
+	}
+	h.escreverJSON(w, http.StatusOK, resp)
 }
 
 // ---- helpers ----

--- a/estudos-platform/backend-platform/internal/presentation/http/handler/auth_handler_test.go
+++ b/estudos-platform/backend-platform/internal/presentation/http/handler/auth_handler_test.go
@@ -42,6 +42,15 @@ func (f *fakeRefresh) Execute(ctx context.Context, refreshToken string) (*dto.Au
 	return f.resp, f.err
 }
 
+type fakePerfil struct {
+	resp *dto.UsuarioResponse
+	err  error
+}
+
+func (f *fakePerfil) Execute(ctx context.Context, usuarioID string) (*dto.UsuarioResponse, error) {
+	return f.resp, f.err
+}
+
 func authResponseFake() *dto.AuthResponse {
 	return &dto.AuthResponse{
 		Tokens:  dto.TokenResponse{AccessToken: "access", RefreshToken: "refresh", ExpiracaoEm: 123},
@@ -63,7 +72,7 @@ func executarHandler(fn http.HandlerFunc, method, target, corpo string, ctx cont
 // ---- testes ----
 
 func TestRegistrar_Sucesso(t *testing.T) {
-	h := NewAuthHandler(&fakeRegistrar{resp: authResponseFake()}, &fakeLogin{}, &fakeRefresh{})
+	h := NewAuthHandler(&fakeRegistrar{resp: authResponseFake()}, &fakeLogin{}, &fakeRefresh{}, &fakePerfil{})
 	w := executarHandler(h.Registrar, http.MethodPost, "/auth/registrar", `{"nome":"Thiago","email":"t@ex.com","senha":"senha123"}`, nil)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("esperava 201, got %d", w.Code)
@@ -71,7 +80,7 @@ func TestRegistrar_Sucesso(t *testing.T) {
 }
 
 func TestRegistrar_CorpoInvalido(t *testing.T) {
-	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{}, &fakeRefresh{})
+	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{}, &fakeRefresh{}, &fakePerfil{})
 	w := executarHandler(h.Registrar, http.MethodPost, "/auth/registrar", `{nao-json`, nil)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("esperava 400, got %d", w.Code)
@@ -79,7 +88,7 @@ func TestRegistrar_CorpoInvalido(t *testing.T) {
 }
 
 func TestRegistrar_Validacao(t *testing.T) {
-	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{}, &fakeRefresh{})
+	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{}, &fakeRefresh{}, &fakePerfil{})
 	w := executarHandler(h.Registrar, http.MethodPost, "/auth/registrar", `{"nome":"T","email":"x","senha":"1"}`, nil)
 	if w.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("esperava 422, got %d", w.Code)
@@ -88,7 +97,7 @@ func TestRegistrar_Validacao(t *testing.T) {
 
 func TestRegistrar_EmailJaCadastrado(t *testing.T) {
 	erro := domainErros.ErrAlreadyExists("e-mail já cadastrado", "test", nil)
-	h := NewAuthHandler(&fakeRegistrar{err: erro}, &fakeLogin{}, &fakeRefresh{})
+	h := NewAuthHandler(&fakeRegistrar{err: erro}, &fakeLogin{}, &fakeRefresh{}, &fakePerfil{})
 	w := executarHandler(h.Registrar, http.MethodPost, "/auth/registrar", `{"nome":"Thiago","email":"t@ex.com","senha":"senha123"}`, nil)
 	if w.Code != http.StatusConflict {
 		t.Fatalf("esperava 409, got %d", w.Code)
@@ -96,7 +105,7 @@ func TestRegistrar_EmailJaCadastrado(t *testing.T) {
 }
 
 func TestLogin_Sucesso(t *testing.T) {
-	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{resp: authResponseFake()}, &fakeRefresh{})
+	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{resp: authResponseFake()}, &fakeRefresh{}, &fakePerfil{})
 	w := executarHandler(h.Login, http.MethodPost, "/auth/login", `{"email":"t@ex.com","senha":"senha123"}`, nil)
 	if w.Code != http.StatusOK {
 		t.Fatalf("esperava 200, got %d", w.Code)
@@ -112,7 +121,7 @@ func TestLogin_Sucesso(t *testing.T) {
 
 func TestLogin_CredenciaisInvalidas(t *testing.T) {
 	erro := domainErros.ErrUnauthorized("credenciais inválidas", "test", nil)
-	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{err: erro}, &fakeRefresh{})
+	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{err: erro}, &fakeRefresh{}, &fakePerfil{})
 	w := executarHandler(h.Login, http.MethodPost, "/auth/login", `{"email":"t@ex.com","senha":"errada"}`, nil)
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("esperava 401, got %d", w.Code)
@@ -120,7 +129,7 @@ func TestLogin_CredenciaisInvalidas(t *testing.T) {
 }
 
 func TestRefresh_Sucesso(t *testing.T) {
-	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{}, &fakeRefresh{resp: authResponseFake()})
+	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{}, &fakeRefresh{resp: authResponseFake()}, &fakePerfil{})
 	w := executarHandler(h.Refresh, http.MethodPost, "/auth/refresh", `{"refresh_token":"token"}`, nil)
 	if w.Code != http.StatusOK {
 		t.Fatalf("esperava 200, got %d", w.Code)
@@ -129,7 +138,7 @@ func TestRefresh_Sucesso(t *testing.T) {
 
 func TestRefresh_TokenInvalido(t *testing.T) {
 	erro := domainErros.ErrUnauthorized("refresh token inválido", "test", nil)
-	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{}, &fakeRefresh{err: erro})
+	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{}, &fakeRefresh{err: erro}, &fakePerfil{})
 	w := executarHandler(h.Refresh, http.MethodPost, "/auth/refresh", `{"refresh_token":"token"}`, nil)
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("esperava 401, got %d", w.Code)
@@ -137,9 +146,9 @@ func TestRefresh_TokenInvalido(t *testing.T) {
 }
 
 func TestMe(t *testing.T) {
-	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{}, &fakeRefresh{})
+	perfil := &fakePerfil{resp: &dto.UsuarioResponse{ID: "u-1", Nome: "Thiago", Email: "t@ex.com"}}
+	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{}, &fakeRefresh{}, perfil)
 	ctx := context.WithValue(context.Background(), middleware.CtxUsuarioID, "u-1")
-	ctx = context.WithValue(ctx, middleware.CtxEmail, "t@ex.com")
 	w := executarHandler(h.Me, http.MethodGet, "/auth/me", "", ctx)
 	if w.Code != http.StatusOK {
 		t.Fatalf("esperava 200, got %d", w.Code)
@@ -148,7 +157,17 @@ func TestMe(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("resposta não é JSON: %v", err)
 	}
-	if resp.Email != "t@ex.com" {
-		t.Errorf("email incorreto: %s", resp.Email)
+	if resp.Nome != "Thiago" || resp.Email != "t@ex.com" {
+		t.Errorf("perfil incorreto: %+v", resp)
+	}
+}
+
+func TestMe_Erro(t *testing.T) {
+	erro := domainErros.ErrNotFound("usuário não encontrado", "test", nil)
+	h := NewAuthHandler(&fakeRegistrar{}, &fakeLogin{}, &fakeRefresh{}, &fakePerfil{err: erro})
+	ctx := context.WithValue(context.Background(), middleware.CtxUsuarioID, "u-inexistente")
+	w := executarHandler(h.Me, http.MethodGet, "/auth/me", "", ctx)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("esperava 404, got %d", w.Code)
 	}
 }

--- a/estudos-platform/backend-platform/internal/presentation/http/router/router.go
+++ b/estudos-platform/backend-platform/internal/presentation/http/router/router.go
@@ -43,9 +43,10 @@ func New(cfg *config.Config, pool *pgxpool.Pool) http.Handler {
 	})
 	loginUC := usecase.NewLoginUsuario(usuarioRepo, refreshRepo, hasher, tokens, tokenCfg)
 	refreshUC := usecase.NewRefreshTokenUC(refreshRepo, usuarioRepo, tokens, tokenCfg)
+	perfilUC := usecase.NewObterPerfil(usuarioRepo)
 
 	// ---- handler (apresentação) ----
-	auth := handler.NewAuthHandler(registrarUC, loginUC, refreshUC)
+	auth := handler.NewAuthHandler(registrarUC, loginUC, refreshUC, perfilUC)
 
 	r.Route("/api/v1", func(api chi.Router) {
 		api.Post("/auth/registrar", auth.Registrar)


### PR DESCRIPTION
Adiciona usecase ObterPerfil que busca o usuario por ID e devolve nome/email, em vez de devolver apenas os dados embutidos no token.

- novo usecase internal/applications/estudos/usecase/obter_perfil.go
- AuthHandler passa a depender da interface ObterPerfilUseCase
- router injeta NewObterPerfil(usuarioRepo)
- testes: ObterPerfil (sucesso/nao encontrado) e handler Me/Me_Erro