### PR TITLE
feat(http): adiciona middleware CORS configurável

### DIFF
--- a/estudos-platform/backend-platform/.env.example
+++ b/estudos-platform/backend-platform/.env.example
@@ -11,3 +11,6 @@ DB_SSL_MODE=disable
 JWT_SECRET=troque-este-segredo-em-producao
 JWT_ACCESS_TTL_MIN=15
 JWT_REFRESH_TTL_HOURS=168
+
+# Origens permitidas (CSV). Use * apenas em desenvolvimento.
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173

--- a/estudos-platform/backend-platform/internal/infrastructure/config/config.go
+++ b/estudos-platform/backend-platform/internal/infrastructure/config/config.go
@@ -4,13 +4,14 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/joho/godotenv"
 )
 
 // Config centraliza todas as variáveis de ambiente da aplicação.
 type Config struct {
-	AppEnv string
+	AppEnv  string
 	AppPort string
 
 	DBHost     string
@@ -20,9 +21,11 @@ type Config struct {
 	DBName     string
 	DBSSLMode  string
 
-	JWTSecret        string
-	JWTAccessTTLMin  int
+	JWTSecret          string
+	JWTAccessTTLMin    int
 	JWTRefreshTTLHours int
+
+	CORSAllowedOrigins []string
 }
 
 func Load() *Config {
@@ -43,6 +46,8 @@ func Load() *Config {
 		JWTSecret:          getEnv("JWT_SECRET", ""),
 		JWTAccessTTLMin:    getEnvInt("JWT_ACCESS_TTL_MIN", 15),
 		JWTRefreshTTLHours: getEnvInt("JWT_REFRESH_TTL_HOURS", 168),
+
+		CORSAllowedOrigins: splitCSV(getEnv("CORS_ALLOWED_ORIGINS", "http://localhost:3000")),
 	}
 
 	if cfg.JWTSecret == "" {
@@ -65,4 +70,16 @@ func getEnvInt(key string, fallback int) int {
 		}
 	}
 	return fallback
+}
+
+func splitCSV(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/estudos-platform/backend-platform/internal/presentation/http/middleware/cors.go
+++ b/estudos-platform/backend-platform/internal/presentation/http/middleware/cors.go
@@ -1,0 +1,57 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+// CORS libera origens configuradas e responde preflight OPTIONS.
+type CORS struct {
+	allowedOrigins map[string]struct{}
+	allowAll       bool
+}
+
+func NewCORS(origins []string) *CORS {
+	c := &CORS{allowedOrigins: make(map[string]struct{}, len(origins))}
+	for _, o := range origins {
+		o = strings.TrimSpace(o)
+		if o == "" {
+			continue
+		}
+		if o == "*" {
+			c.allowAll = true
+			continue
+		}
+		c.allowedOrigins[o] = struct{}{}
+	}
+	return c
+}
+
+func (c *CORS) Handler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		if origin != "" && c.origemPermitida(origin) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Vary", "Origin")
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Request-ID")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Max-Age", "600")
+		}
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (c *CORS) origemPermitida(origin string) bool {
+	if c.allowAll {
+		return true
+	}
+	_, ok := c.allowedOrigins[origin]
+	return ok
+}

--- a/estudos-platform/backend-platform/internal/presentation/http/middleware/cors_test.go
+++ b/estudos-platform/backend-platform/internal/presentation/http/middleware/cors_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCORS_OrigemPermitida(t *testing.T) {
+	cors := NewCORS([]string{"http://localhost:3000"})
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := cors.Handler(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "http://localhost:3000" {
+		t.Fatalf("header CORS ausente: %v", w.Header())
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("esperava 200, got %d", w.Code)
+	}
+}
+
+func TestCORS_OrigemNegada(t *testing.T) {
+	cors := NewCORS([]string{"http://localhost:3000"})
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := cors.Handler(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Fatal("não deveria liberar origem não listada")
+	}
+}
+
+func TestCORS_Preflight(t *testing.T) {
+	cors := NewCORS([]string{"http://localhost:3000"})
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	h := cors.Handler(next)
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/auth/login", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("esperava 204, got %d", w.Code)
+	}
+	if called {
+		t.Fatal("preflight não deve chamar o próximo handler")
+	}
+}
+
+func TestCORS_AllowAll(t *testing.T) {
+	cors := NewCORS([]string{"*"})
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := cors.Handler(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Origin", "https://qualquer.app")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "https://qualquer.app" {
+		t.Fatalf("esperava ecoar origem com *, got %q", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+}

--- a/estudos-platform/backend-platform/internal/presentation/http/router/router.go
+++ b/estudos-platform/backend-platform/internal/presentation/http/router/router.go
@@ -19,6 +19,7 @@ func New(cfg *config.Config, pool *pgxpool.Pool) http.Handler {
 
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Recovery)
+	r.Use(middleware.NewCORS(cfg.CORSAllowedOrigins).Handler)
 
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary
- Middleware CORS com allowlist via `CORS_ALLOWED_ORIGINS` (CSV; `*` só para dev)
- Preflight OPTIONS com 204
- Defaults para localhost:3000/5173 no `.env.example`

## Test plan
- [ ] `go test ./internal/presentation/http/middleware/ -count=1`
- [ ] Request com Origin permitida deve ecoar `Access-Control-Allow-Origin`
- [ ] OPTIONS em `/api/v1/auth/login` retorna 204