### PR TITLE
feat(trilhas): CRUD de trilhas e módulos

### DIFF
--- a/estudos-platform/backend-platform/Makefile
+++ b/estudos-platform/backend-platform/Makefile
@@ -12,8 +12,12 @@ run:            ## roda direto
 migrate-up:     ## aplica migrations
 	docker exec -i estudos-postgres psql -U estudos -d estudos_platform \
 	  < internal/infrastructure/persistence/postgres/migration/0001_create_usuario.up.sql
+	docker exec -i estudos-postgres psql -U estudos -d estudos_platform \
+	  < internal/infrastructure/persistence/postgres/migration/0003_create_trilhas.up.sql
 
 migrate-down:   ## reverte migrations
+	docker exec -i estudos-postgres psql -U estudos -d estudos_platform \
+	  < internal/infrastructure/persistence/postgres/migration/0003_create_trilhas.down.sql
 	docker exec -i estudos-postgres psql -U estudos -d estudos_platform \
 	  < internal/infrastructure/persistence/postgres/migration/0001_create_usuario.down.sql
 

--- a/estudos-platform/backend-platform/internal/applications/estudos/dto/trilha_dto.go
+++ b/estudos-platform/backend-platform/internal/applications/estudos/dto/trilha_dto.go
@@ -1,0 +1,40 @@
+package dto
+
+type CriarTrilhaRequest struct {
+	Titulo    string `json:"titulo" validate:"required,min=3,max=200"`
+	Descricao string `json:"descricao" validate:"omitempty,max=2000"`
+	CapaURL   string `json:"capa_url" validate:"omitempty,url"`
+	Slug      string `json:"slug" validate:"omitempty,min=2,max=200"`
+	Ordem     int    `json:"ordem" validate:"omitempty,min=0"`
+}
+
+type AdicionarModuloRequest struct {
+	Titulo    string `json:"titulo" validate:"required,min=2,max=200"`
+	Descricao string `json:"descricao" validate:"omitempty,max=2000"`
+	Slug      string `json:"slug" validate:"omitempty,min=2,max=200"`
+}
+
+type ModuloResponse struct {
+	ID        string `json:"id"`
+	Slug      string `json:"slug"`
+	Titulo    string `json:"titulo"`
+	Descricao string `json:"descricao,omitempty"`
+	Ordem     int    `json:"ordem"`
+}
+
+type TrilhaResponse struct {
+	ID        string           `json:"id"`
+	Slug      string           `json:"slug"`
+	Titulo    string           `json:"titulo"`
+	Descricao string           `json:"descricao,omitempty"`
+	CapaURL   string           `json:"capa_url,omitempty"`
+	Ordem     int              `json:"ordem"`
+	Publicada bool             `json:"publicada"`
+	Modulos   []ModuloResponse `json:"modulos"`
+	CreatedAt int64            `json:"created_at"`
+	UpdatedAt int64            `json:"updated_at"`
+}
+
+type ListarTrilhasResponse struct {
+	Itens []*TrilhaResponse `json:"itens"`
+}

--- a/estudos-platform/backend-platform/internal/applications/estudos/usecase/adicionar_modulo.go
+++ b/estudos-platform/backend-platform/internal/applications/estudos/usecase/adicionar_modulo.go
@@ -1,0 +1,46 @@
+package usecase
+
+import (
+	"context"
+	stderrors "errors"
+
+	"github.com/thiago-tertuliano/estudos-platform/internal/applications/estudos/dto"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/repository"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/valueobject"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+type AdicionarModulo struct {
+	repo repository.TrilhaRepository
+}
+
+func NewAdicionarModulo(repo repository.TrilhaRepository) *AdicionarModulo {
+	return &AdicionarModulo{repo: repo}
+}
+
+func (uc *AdicionarModulo) Execute(ctx context.Context, trilhaID string, req dto.AdicionarModuloRequest) (*dto.TrilhaResponse, error) {
+	trilha, err := uc.repo.FindByID(ctx, trilhaID)
+	if err != nil {
+		var de *errors.DomainError
+		if stderrors.As(err, &de) && de.Kind == errors.NotFound {
+			return nil, errors.ErrNotFound("trilha não encontrada", "AdicionarModulo.Execute", nil)
+		}
+		return nil, errors.ErrInternal("falha ao buscar trilha", "AdicionarModulo.Execute", err)
+	}
+
+	slugRaw := req.Slug
+	if slugRaw == "" {
+		slugRaw = req.Titulo
+	}
+	slug, err := valueobject.NewSlug(slugRaw)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := trilha.AdicionarModulo(slug, req.Titulo, req.Descricao); err != nil {
+		return nil, err
+	}
+	if err := uc.repo.Save(ctx, trilha); err != nil {
+		return nil, errors.ErrInternal("falha ao salvar módulo", "AdicionarModulo.Execute", err)
+	}
+	return toTrilhaResponse(trilha), nil
+}

--- a/estudos-platform/backend-platform/internal/applications/estudos/usecase/criar_trilha.go
+++ b/estudos-platform/backend-platform/internal/applications/estudos/usecase/criar_trilha.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	stderrors "errors"
+
+	"github.com/thiago-tertuliano/estudos-platform/internal/applications/estudos/dto"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/entity"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/repository"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/valueobject"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+type CriarTrilha struct {
+	repo repository.TrilhaRepository
+}
+
+func NewCriarTrilha(repo repository.TrilhaRepository) *CriarTrilha {
+	return &CriarTrilha{repo: repo}
+}
+
+func (uc *CriarTrilha) Execute(ctx context.Context, req dto.CriarTrilhaRequest) (*dto.TrilhaResponse, error) {
+	slugRaw := req.Slug
+	if slugRaw == "" {
+		slugRaw = req.Titulo
+	}
+	slug, err := valueobject.NewSlug(slugRaw)
+	if err != nil {
+		return nil, err
+	}
+	existe, err := uc.repo.SlugExiste(ctx, slug)
+	if err != nil {
+		return nil, errors.ErrInternal("falha ao verificar slug", "CriarTrilha.Execute", err)
+	}
+	if existe {
+		return nil, errors.ErrAlreadyExists("slug já utilizado", "CriarTrilha.Execute", nil)
+	}
+
+	trilha, err := entity.NovaTrilha(entity.NovaTrilhaInput{
+		Slug: slug, Titulo: req.Titulo, Descricao: req.Descricao, CapaURL: req.CapaURL, Ordem: req.Ordem,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := uc.repo.Save(ctx, trilha); err != nil {
+		var de *errors.DomainError
+		if stderrors.As(err, &de) {
+			return nil, err
+		}
+		return nil, errors.ErrInternal("falha ao salvar trilha", "CriarTrilha.Execute", err)
+	}
+	return toTrilhaResponse(trilha), nil
+}

--- a/estudos-platform/backend-platform/internal/applications/estudos/usecase/criar_trilha_test.go
+++ b/estudos-platform/backend-platform/internal/applications/estudos/usecase/criar_trilha_test.go
@@ -1,0 +1,87 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/thiago-tertuliano/estudos-platform/internal/applications/estudos/dto"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/entity"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/valueobject"
+	domainErros "github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+type MockTrilhaRepository struct {
+	SaveFn           func(ctx context.Context, t *entity.Trilha) error
+	FindByIDFn       func(ctx context.Context, id string) (*entity.Trilha, error)
+	FindBySlugFn     func(ctx context.Context, slug valueobject.Slug) (*entity.Trilha, error)
+	ListPublicadasFn func(ctx context.Context, limit, offset int) ([]*entity.Trilha, error)
+	SlugExisteFn     func(ctx context.Context, slug valueobject.Slug) (bool, error)
+}
+
+func (m *MockTrilhaRepository) Save(ctx context.Context, t *entity.Trilha) error {
+	return m.SaveFn(ctx, t)
+}
+func (m *MockTrilhaRepository) FindByID(ctx context.Context, id string) (*entity.Trilha, error) {
+	return m.FindByIDFn(ctx, id)
+}
+func (m *MockTrilhaRepository) FindBySlug(ctx context.Context, slug valueobject.Slug) (*entity.Trilha, error) {
+	return m.FindBySlugFn(ctx, slug)
+}
+func (m *MockTrilhaRepository) ListPublicadas(ctx context.Context, limit, offset int) ([]*entity.Trilha, error) {
+	return m.ListPublicadasFn(ctx, limit, offset)
+}
+func (m *MockTrilhaRepository) SlugExiste(ctx context.Context, slug valueobject.Slug) (bool, error) {
+	return m.SlugExisteFn(ctx, slug)
+}
+
+func TestCriarTrilha_Sucesso(t *testing.T) {
+	repo := &MockTrilhaRepository{
+		SlugExisteFn: func(ctx context.Context, slug valueobject.Slug) (bool, error) { return false, nil },
+		SaveFn:       func(ctx context.Context, tr *entity.Trilha) error { return nil },
+	}
+	uc := NewCriarTrilha(repo)
+	resp, err := uc.Execute(context.Background(), dto.CriarTrilhaRequest{Titulo: "Clean Architecture"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Slug != "clean-architecture" || resp.Publicada {
+		t.Fatalf("resposta inesperada: %+v", resp)
+	}
+}
+
+func TestAdicionarModuloEPublicar(t *testing.T) {
+	slug, _ := valueobject.NewSlug("ddd")
+	trilha, _ := entity.NovaTrilha(entity.NovaTrilhaInput{Slug: slug, Titulo: "DDD"})
+	repo := &MockTrilhaRepository{
+		FindByIDFn: func(ctx context.Context, id string) (*entity.Trilha, error) { return trilha, nil },
+		SaveFn:     func(ctx context.Context, tr *entity.Trilha) error { return nil },
+	}
+
+	addUC := NewAdicionarModulo(repo)
+	if _, err := addUC.Execute(context.Background(), trilha.ID().String(), dto.AdicionarModuloRequest{
+		Titulo: "Aggregates",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	pubUC := NewPublicarTrilha(repo)
+	resp, err := pubUC.Execute(context.Background(), trilha.ID().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Publicada || len(resp.Modulos) != 1 {
+		t.Fatalf("esperava publicada com 1 módulo: %+v", resp)
+	}
+}
+
+func TestPublicarTrilha_SemModulos(t *testing.T) {
+	slug, _ := valueobject.NewSlug("vazia")
+	trilha, _ := entity.NovaTrilha(entity.NovaTrilhaInput{Slug: slug, Titulo: "Vazia"})
+	repo := &MockTrilhaRepository{
+		FindByIDFn: func(ctx context.Context, id string) (*entity.Trilha, error) { return trilha, nil },
+	}
+	_, err := NewPublicarTrilha(repo).Execute(context.Background(), trilha.ID().String())
+	if de, ok := err.(*domainErros.DomainError); !ok || de.Kind != domainErros.InvalidState {
+		t.Fatalf("esperava InvalidState, got %#v", err)
+	}
+}

--- a/estudos-platform/backend-platform/internal/applications/estudos/usecase/listar_trilhas.go
+++ b/estudos-platform/backend-platform/internal/applications/estudos/usecase/listar_trilhas.go
@@ -1,0 +1,35 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/thiago-tertuliano/estudos-platform/internal/applications/estudos/dto"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/repository"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+type ListarTrilhas struct {
+	repo repository.TrilhaRepository
+}
+
+func NewListarTrilhas(repo repository.TrilhaRepository) *ListarTrilhas {
+	return &ListarTrilhas{repo: repo}
+}
+
+func (uc *ListarTrilhas) Execute(ctx context.Context, limit, offset int) (*dto.ListarTrilhasResponse, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	itens, err := uc.repo.ListPublicadas(ctx, limit, offset)
+	if err != nil {
+		return nil, errors.ErrInternal("falha ao listar trilhas", "ListarTrilhas.Execute", err)
+	}
+	out := make([]*dto.TrilhaResponse, 0, len(itens))
+	for _, t := range itens {
+		out = append(out, toTrilhaResponse(t))
+	}
+	return &dto.ListarTrilhasResponse{Itens: out}, nil
+}

--- a/estudos-platform/backend-platform/internal/applications/estudos/usecase/obter_trilha.go
+++ b/estudos-platform/backend-platform/internal/applications/estudos/usecase/obter_trilha.go
@@ -1,0 +1,38 @@
+package usecase
+
+import (
+	"context"
+	stderrors "errors"
+
+	"github.com/thiago-tertuliano/estudos-platform/internal/applications/estudos/dto"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/repository"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/valueobject"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+type ObterTrilha struct {
+	repo repository.TrilhaRepository
+}
+
+func NewObterTrilha(repo repository.TrilhaRepository) *ObterTrilha {
+	return &ObterTrilha{repo: repo}
+}
+
+func (uc *ObterTrilha) Execute(ctx context.Context, slugRaw string) (*dto.TrilhaResponse, error) {
+	slug, err := valueobject.NewSlug(slugRaw)
+	if err != nil {
+		return nil, err
+	}
+	trilha, err := uc.repo.FindBySlug(ctx, slug)
+	if err != nil {
+		var de *errors.DomainError
+		if stderrors.As(err, &de) && de.Kind == errors.NotFound {
+			return nil, errors.ErrNotFound("trilha não encontrada", "ObterTrilha.Execute", nil)
+		}
+		return nil, errors.ErrInternal("falha ao buscar trilha", "ObterTrilha.Execute", err)
+	}
+	if !trilha.Publicada() {
+		return nil, errors.ErrNotFound("trilha não encontrada", "ObterTrilha.Execute", nil)
+	}
+	return toTrilhaResponse(trilha), nil
+}

--- a/estudos-platform/backend-platform/internal/applications/estudos/usecase/publicar_trilha.go
+++ b/estudos-platform/backend-platform/internal/applications/estudos/usecase/publicar_trilha.go
@@ -1,0 +1,36 @@
+package usecase
+
+import (
+	"context"
+	stderrors "errors"
+
+	"github.com/thiago-tertuliano/estudos-platform/internal/applications/estudos/dto"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/repository"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+type PublicarTrilha struct {
+	repo repository.TrilhaRepository
+}
+
+func NewPublicarTrilha(repo repository.TrilhaRepository) *PublicarTrilha {
+	return &PublicarTrilha{repo: repo}
+}
+
+func (uc *PublicarTrilha) Execute(ctx context.Context, id string) (*dto.TrilhaResponse, error) {
+	trilha, err := uc.repo.FindByID(ctx, id)
+	if err != nil {
+		var de *errors.DomainError
+		if stderrors.As(err, &de) && de.Kind == errors.NotFound {
+			return nil, errors.ErrNotFound("trilha não encontrada", "PublicarTrilha.Execute", nil)
+		}
+		return nil, errors.ErrInternal("falha ao buscar trilha", "PublicarTrilha.Execute", err)
+	}
+	if err := trilha.Publicar(); err != nil {
+		return nil, err
+	}
+	if err := uc.repo.Save(ctx, trilha); err != nil {
+		return nil, errors.ErrInternal("falha ao publicar trilha", "PublicarTrilha.Execute", err)
+	}
+	return toTrilhaResponse(trilha), nil
+}

--- a/estudos-platform/backend-platform/internal/applications/estudos/usecase/trilha_mapper.go
+++ b/estudos-platform/backend-platform/internal/applications/estudos/usecase/trilha_mapper.go
@@ -1,0 +1,31 @@
+package usecase
+
+import (
+	"github.com/thiago-tertuliano/estudos-platform/internal/applications/estudos/dto"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/entity"
+)
+
+func toTrilhaResponse(t *entity.Trilha) *dto.TrilhaResponse {
+	mods := make([]dto.ModuloResponse, 0, len(t.Modulos()))
+	for _, m := range t.Modulos() {
+		mods = append(mods, dto.ModuloResponse{
+			ID:        m.ID().String(),
+			Slug:      m.Slug().Value(),
+			Titulo:    m.Titulo(),
+			Descricao: m.Descricao(),
+			Ordem:     m.Ordem(),
+		})
+	}
+	return &dto.TrilhaResponse{
+		ID:        t.ID().String(),
+		Slug:      t.Slug().Value(),
+		Titulo:    t.Titulo(),
+		Descricao: t.Descricao(),
+		CapaURL:   t.CapaURL(),
+		Ordem:     t.Ordem(),
+		Publicada: t.Publicada(),
+		Modulos:   mods,
+		CreatedAt: t.CreatedAt().Unix(),
+		UpdatedAt: t.UpdatedAt().Unix(),
+	}
+}

--- a/estudos-platform/backend-platform/internal/domain/estudos/entity/trilha.go
+++ b/estudos-platform/backend-platform/internal/domain/estudos/entity/trilha.go
@@ -1,0 +1,138 @@
+package entity
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/valueobject"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/kernel"
+)
+
+// Modulo é entidade filha de Trilha (sem root próprio).
+type Modulo struct {
+	id        uuid.UUID
+	slug      valueobject.Slug
+	titulo    string
+	descricao string
+	ordem     int
+	createdAt time.Time
+}
+
+func NovoModulo(slug valueobject.Slug, titulo, descricao string, ordem int) (*Modulo, error) {
+	if len(titulo) < 2 || len(titulo) > 200 {
+		return nil, errors.ErrInvalidArgument("título do módulo inválido", "entity.NovoModulo", nil)
+	}
+	return &Modulo{
+		id:        uuid.New(),
+		slug:      slug,
+		titulo:    titulo,
+		descricao: descricao,
+		ordem:     ordem,
+		createdAt: time.Now().UTC(),
+	}, nil
+}
+
+func ReconstruirModulo(id uuid.UUID, slug valueobject.Slug, titulo, descricao string, ordem int, createdAt time.Time) *Modulo {
+	return &Modulo{id: id, slug: slug, titulo: titulo, descricao: descricao, ordem: ordem, createdAt: createdAt}
+}
+
+func (m *Modulo) ID() uuid.UUID            { return m.id }
+func (m *Modulo) Slug() valueobject.Slug   { return m.slug }
+func (m *Modulo) Titulo() string           { return m.titulo }
+func (m *Modulo) Descricao() string        { return m.descricao }
+func (m *Modulo) Ordem() int               { return m.ordem }
+func (m *Modulo) CreatedAt() time.Time     { return m.createdAt }
+
+// Trilha é Aggregate Root de trilhas de estudo.
+type Trilha struct {
+	kernel.BaseEntity
+	slug       valueobject.Slug
+	titulo     string
+	descricao  string
+	capaURL    string
+	ordem      int
+	publicada  bool
+	modulos    []*Modulo
+}
+
+type NovaTrilhaInput struct {
+	Slug      valueobject.Slug
+	Titulo    string
+	Descricao string
+	CapaURL   string
+	Ordem     int
+}
+
+func NovaTrilha(in NovaTrilhaInput) (*Trilha, error) {
+	if len(in.Titulo) < 3 || len(in.Titulo) > 200 {
+		return nil, errors.ErrInvalidArgument("título deve ter entre 3 e 200 caracteres", "entity.NovaTrilha", nil)
+	}
+	return &Trilha{
+		BaseEntity: kernel.NewBaseEntity(),
+		slug:       in.Slug,
+		titulo:     in.Titulo,
+		descricao:  in.Descricao,
+		capaURL:    in.CapaURL,
+		ordem:      in.Ordem,
+		publicada:  false,
+		modulos:    []*Modulo{},
+	}, nil
+}
+
+func ReconstruirTrilha(
+	id uuid.UUID,
+	slug valueobject.Slug,
+	titulo, descricao, capaURL string,
+	ordem int,
+	publicada bool,
+	modulos []*Modulo,
+	createdAt, updatedAt time.Time,
+) *Trilha {
+	if modulos == nil {
+		modulos = []*Modulo{}
+	}
+	return &Trilha{
+		BaseEntity: kernel.NewBaseEntityWithID(id, createdAt, updatedAt),
+		slug:       slug,
+		titulo:     titulo,
+		descricao:  descricao,
+		capaURL:    capaURL,
+		ordem:      ordem,
+		publicada:  publicada,
+		modulos:    modulos,
+	}
+}
+
+func (t *Trilha) Slug() valueobject.Slug { return t.slug }
+func (t *Trilha) Titulo() string         { return t.titulo }
+func (t *Trilha) Descricao() string      { return t.descricao }
+func (t *Trilha) CapaURL() string        { return t.capaURL }
+func (t *Trilha) Ordem() int             { return t.ordem }
+func (t *Trilha) Publicada() bool        { return t.publicada }
+func (t *Trilha) Modulos() []*Modulo     { return t.modulos }
+
+func (t *Trilha) AdicionarModulo(slug valueobject.Slug, titulo, descricao string) (*Modulo, error) {
+	for _, m := range t.modulos {
+		if m.slug.Equals(slug) {
+			return nil, errors.ErrAlreadyExists("slug de módulo já existe nesta trilha", "Trilha.AdicionarModulo", nil)
+		}
+	}
+	ordem := len(t.modulos)
+	mod, err := NovoModulo(slug, titulo, descricao, ordem)
+	if err != nil {
+		return nil, err
+	}
+	t.modulos = append(t.modulos, mod)
+	t.Touch()
+	return mod, nil
+}
+
+func (t *Trilha) Publicar() error {
+	if len(t.modulos) == 0 {
+		return errors.ErrInvalidState("trilha sem módulos não pode ser publicada", "Trilha.Publicar", nil)
+	}
+	t.publicada = true
+	t.Touch()
+	return nil
+}

--- a/estudos-platform/backend-platform/internal/domain/estudos/entity/trilha_test.go
+++ b/estudos-platform/backend-platform/internal/domain/estudos/entity/trilha_test.go
@@ -1,0 +1,35 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/valueobject"
+	domainErros "github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+func TestTrilha_AdicionarModuloEPublicar(t *testing.T) {
+	slug, _ := valueobject.NewSlug("go-avancado")
+	trilha, err := NovaTrilha(NovaTrilhaInput{Slug: slug, Titulo: "Go Avançado", Descricao: "trilha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	modSlug, _ := valueobject.NewSlug("concurrency")
+	if _, err := trilha.AdicionarModulo(modSlug, "Concorrência", "goroutines"); err != nil {
+		t.Fatal(err)
+	}
+	if err := trilha.Publicar(); err != nil {
+		t.Fatal(err)
+	}
+	if !trilha.Publicada() || len(trilha.Modulos()) != 1 {
+		t.Fatal("trilha deveria estar publicada com 1 módulo")
+	}
+}
+
+func TestTrilha_PublicarSemModulos(t *testing.T) {
+	slug, _ := valueobject.NewSlug("vazia")
+	trilha, _ := NovaTrilha(NovaTrilhaInput{Slug: slug, Titulo: "Vazia"})
+	err := trilha.Publicar()
+	if de, ok := err.(*domainErros.DomainError); !ok || de.Kind != domainErros.InvalidState {
+		t.Fatalf("esperava InvalidState, got %#v", err)
+	}
+}

--- a/estudos-platform/backend-platform/internal/domain/estudos/repository/trilha_repository.go
+++ b/estudos-platform/backend-platform/internal/domain/estudos/repository/trilha_repository.go
@@ -1,0 +1,16 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/entity"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/valueobject"
+)
+
+type TrilhaRepository interface {
+	Save(ctx context.Context, t *entity.Trilha) error
+	FindByID(ctx context.Context, id string) (*entity.Trilha, error)
+	FindBySlug(ctx context.Context, slug valueobject.Slug) (*entity.Trilha, error)
+	ListPublicadas(ctx context.Context, limit, offset int) ([]*entity.Trilha, error)
+	SlugExiste(ctx context.Context, slug valueobject.Slug) (bool, error)
+}

--- a/estudos-platform/backend-platform/internal/domain/estudos/valueobject/slug.go
+++ b/estudos-platform/backend-platform/internal/domain/estudos/valueobject/slug.go
@@ -1,0 +1,63 @@
+package valueobject
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+var slugPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+var accentMap = map[rune]rune{
+	'á': 'a', 'à': 'a', 'ã': 'a', 'â': 'a', 'ä': 'a',
+	'é': 'e', 'è': 'e', 'ê': 'e', 'ë': 'e',
+	'í': 'i', 'ì': 'i', 'î': 'i', 'ï': 'i',
+	'ó': 'o', 'ò': 'o', 'õ': 'o', 'ô': 'o', 'ö': 'o',
+	'ú': 'u', 'ù': 'u', 'û': 'u', 'ü': 'u',
+	'ç': 'c', 'ñ': 'n',
+}
+
+// Slug é URL canônica (VO).
+type Slug struct {
+	value string
+}
+
+func NewSlug(raw string) (Slug, error) {
+	normalized := normalizeSlug(raw)
+	if len(normalized) < 2 || len(normalized) > 200 {
+		return Slug{}, errors.ErrInvalidArgument("slug deve ter entre 2 e 200 caracteres", "valueobject.NewSlug", nil)
+	}
+	if !slugPattern.MatchString(normalized) {
+		return Slug{}, errors.ErrInvalidArgument("slug inválido", "valueobject.NewSlug", nil)
+	}
+	return Slug{value: normalized}, nil
+}
+
+func ReconstructSlug(value string) Slug { return Slug{value: value} }
+
+func (s Slug) Value() string      { return s.value }
+func (s Slug) String() string     { return s.value }
+func (s Slug) Equals(o Slug) bool { return s.value == o.value }
+
+func normalizeSlug(raw string) string {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range raw {
+		if mapped, ok := accentMap[r]; ok {
+			r = mapped
+		}
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevHyphen = false
+		case r == ' ' || r == '_' || r == '-':
+			if !prevHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/estudos-platform/backend-platform/internal/domain/estudos/valueobject/slug_test.go
+++ b/estudos-platform/backend-platform/internal/domain/estudos/valueobject/slug_test.go
@@ -1,0 +1,29 @@
+package valueobject
+
+import "testing"
+
+func TestNewSlug_Sucesso(t *testing.T) {
+	s, err := NewSlug("  Arquitetura DDD  ")
+	if err != nil {
+		t.Fatalf("erro inesperado: %v", err)
+	}
+	if s.Value() != "arquitetura-ddd" {
+		t.Errorf("got %q", s.Value())
+	}
+}
+
+func TestNewSlug_Acentos(t *testing.T) {
+	s, err := NewSlug("Introdução à Programação")
+	if err != nil {
+		t.Fatalf("erro inesperado: %v", err)
+	}
+	if s.Value() != "introducao-a-programacao" {
+		t.Errorf("got %q", s.Value())
+	}
+}
+
+func TestNewSlug_Invalido(t *testing.T) {
+	if _, err := NewSlug("a"); err == nil {
+		t.Fatal("esperava erro para slug curto")
+	}
+}

--- a/estudos-platform/backend-platform/internal/infrastructure/persistence/postgres/migration/0003_create_trilhas.down.sql
+++ b/estudos-platform/backend-platform/internal/infrastructure/persistence/postgres/migration/0003_create_trilhas.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS modulos;
+DROP TABLE IF EXISTS trilhas;

--- a/estudos-platform/backend-platform/internal/infrastructure/persistence/postgres/migration/0003_create_trilhas.up.sql
+++ b/estudos-platform/backend-platform/internal/infrastructure/persistence/postgres/migration/0003_create_trilhas.up.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS trilhas (
+    id UUID PRIMARY KEY,
+    slug VARCHAR(200) NOT NULL UNIQUE,
+    titulo VARCHAR(200) NOT NULL,
+    descricao TEXT,
+    capa_url TEXT,
+    ordem INT NOT NULL DEFAULT 0,
+    publicada BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS modulos (
+    id UUID PRIMARY KEY,
+    trilha_id UUID NOT NULL REFERENCES trilhas(id) ON DELETE CASCADE,
+    slug VARCHAR(200) NOT NULL,
+    titulo VARCHAR(200) NOT NULL,
+    descricao TEXT,
+    ordem INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (trilha_id, slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_trilhas_publicada ON trilhas(publicada);
+CREATE INDEX IF NOT EXISTS idx_modulos_trilha ON modulos(trilha_id);

--- a/estudos-platform/backend-platform/internal/infrastructure/persistence/postgres/repository/trilha_repo_pg.go
+++ b/estudos-platform/backend-platform/internal/infrastructure/persistence/postgres/repository/trilha_repo_pg.go
@@ -1,0 +1,197 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/entity"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/valueobject"
+	domainErros "github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+type TrilhaRepoPG struct {
+	pool *pgxpool.Pool
+}
+
+func NewTrilhaRepoPG(pool *pgxpool.Pool) *TrilhaRepoPG {
+	return &TrilhaRepoPG{pool: pool}
+}
+
+func (r *TrilhaRepoPG) Save(ctx context.Context, t *entity.Trilha) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO trilhas (id, slug, titulo, descricao, capa_url, ordem, publicada, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+		ON CONFLICT (id) DO UPDATE SET
+			titulo = EXCLUDED.titulo,
+			descricao = EXCLUDED.descricao,
+			capa_url = EXCLUDED.capa_url,
+			ordem = EXCLUDED.ordem,
+			publicada = EXCLUDED.publicada,
+			updated_at = EXCLUDED.updated_at
+	`, t.ID(), t.Slug().Value(), t.Titulo(), nullStr(t.Descricao()), nullStr(t.CapaURL()),
+		t.Ordem(), t.Publicada(), t.CreatedAt(), t.UpdatedAt())
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return domainErros.ErrAlreadyExists("slug já utilizado", "trilha_repo_pg.Save", nil)
+		}
+		return err
+	}
+
+	if _, err := tx.Exec(ctx, `DELETE FROM modulos WHERE trilha_id = $1`, t.ID()); err != nil {
+		return err
+	}
+	for _, m := range t.Modulos() {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO modulos (id, trilha_id, slug, titulo, descricao, ordem, created_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7)
+		`, m.ID(), t.ID(), m.Slug().Value(), m.Titulo(), nullStr(m.Descricao()), m.Ordem(), m.CreatedAt()); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (r *TrilhaRepoPG) FindByID(ctx context.Context, id string) (*entity.Trilha, error) {
+	row := r.pool.QueryRow(ctx, `
+		SELECT id, slug, titulo, descricao, capa_url, ordem, publicada, created_at, updated_at
+		FROM trilhas WHERE id = $1
+	`, id)
+	return r.scanTrilhaComModulos(ctx, row)
+}
+
+func (r *TrilhaRepoPG) FindBySlug(ctx context.Context, slug valueobject.Slug) (*entity.Trilha, error) {
+	row := r.pool.QueryRow(ctx, `
+		SELECT id, slug, titulo, descricao, capa_url, ordem, publicada, created_at, updated_at
+		FROM trilhas WHERE slug = $1
+	`, slug.Value())
+	return r.scanTrilhaComModulos(ctx, row)
+}
+
+func (r *TrilhaRepoPG) ListPublicadas(ctx context.Context, limit, offset int) ([]*entity.Trilha, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT id, slug, titulo, descricao, capa_url, ordem, publicada, created_at, updated_at
+		FROM trilhas
+		WHERE publicada = true
+		ORDER BY ordem ASC, created_at DESC
+		LIMIT $1 OFFSET $2
+	`, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []*entity.Trilha
+	for rows.Next() {
+		t, err := r.scanTrilhaComModulos(ctx, rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+func (r *TrilhaRepoPG) SlugExiste(ctx context.Context, slug valueobject.Slug) (bool, error) {
+	var existe bool
+	err := r.pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM trilhas WHERE slug = $1)`, slug.Value()).Scan(&existe)
+	return existe, err
+}
+
+type trilhaRow interface {
+	Scan(dest ...any) error
+}
+
+func (r *TrilhaRepoPG) scanTrilhaComModulos(ctx context.Context, row trilhaRow) (*entity.Trilha, error) {
+	var (
+		id         uuid.UUID
+		slug       string
+		titulo     string
+		descricao  *string
+		capaURL    *string
+		ordem      int
+		publicada  bool
+		createdAt  time.Time
+		updatedAt  time.Time
+	)
+	if err := row.Scan(&id, &slug, &titulo, &descricao, &capaURL, &ordem, &publicada, &createdAt, &updatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domainErros.ErrNotFound("trilha não encontrada", "trilha_repo_pg.scan", nil)
+		}
+		return nil, err
+	}
+
+	modulos, err := r.loadModulos(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return entity.ReconstruirTrilha(
+		id,
+		valueobject.ReconstructSlug(slug),
+		titulo,
+		derefStr(descricao),
+		derefStr(capaURL),
+		ordem,
+		publicada,
+		modulos,
+		createdAt,
+		updatedAt,
+	), nil
+}
+
+func (r *TrilhaRepoPG) loadModulos(ctx context.Context, trilhaID uuid.UUID) ([]*entity.Modulo, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT id, slug, titulo, descricao, ordem, created_at
+		FROM modulos WHERE trilha_id = $1 ORDER BY ordem ASC
+	`, trilhaID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []*entity.Modulo
+	for rows.Next() {
+		var (
+			id        uuid.UUID
+			slug      string
+			titulo    string
+			descricao *string
+			ordem     int
+			createdAt time.Time
+		)
+		if err := rows.Scan(&id, &slug, &titulo, &descricao, &ordem, &createdAt); err != nil {
+			return nil, err
+		}
+		out = append(out, entity.ReconstruirModulo(
+			id, valueobject.ReconstructSlug(slug), titulo, derefStr(descricao), ordem, createdAt,
+		))
+	}
+	return out, rows.Err()
+}
+
+func nullStr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func derefStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/estudos-platform/backend-platform/internal/presentation/http/handler/trilha_handler.go
+++ b/estudos-platform/backend-platform/internal/presentation/http/handler/trilha_handler.go
@@ -1,0 +1,154 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-playground/validator/v10"
+	"github.com/thiago-tertuliano/estudos-platform/internal/applications/estudos/dto"
+	domainErros "github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+type CriarTrilhaUseCase interface {
+	Execute(ctx context.Context, req dto.CriarTrilhaRequest) (*dto.TrilhaResponse, error)
+}
+
+type ObterTrilhaUseCase interface {
+	Execute(ctx context.Context, slug string) (*dto.TrilhaResponse, error)
+}
+
+type ListarTrilhasUseCase interface {
+	Execute(ctx context.Context, limit, offset int) (*dto.ListarTrilhasResponse, error)
+}
+
+type AdicionarModuloUseCase interface {
+	Execute(ctx context.Context, trilhaID string, req dto.AdicionarModuloRequest) (*dto.TrilhaResponse, error)
+}
+
+type PublicarTrilhaUseCase interface {
+	Execute(ctx context.Context, id string) (*dto.TrilhaResponse, error)
+}
+
+type TrilhaHandler struct {
+	criar     CriarTrilhaUseCase
+	obter     ObterTrilhaUseCase
+	listar    ListarTrilhasUseCase
+	adicionar AdicionarModuloUseCase
+	publicar  PublicarTrilhaUseCase
+	validate  *validator.Validate
+}
+
+func NewTrilhaHandler(
+	criar CriarTrilhaUseCase,
+	obter ObterTrilhaUseCase,
+	listar ListarTrilhasUseCase,
+	adicionar AdicionarModuloUseCase,
+	publicar PublicarTrilhaUseCase,
+) *TrilhaHandler {
+	return &TrilhaHandler{
+		criar: criar, obter: obter, listar: listar,
+		adicionar: adicionar, publicar: publicar,
+		validate: validator.New(),
+	}
+}
+
+func (h *TrilhaHandler) Criar(w http.ResponseWriter, r *http.Request) {
+	var req dto.CriarTrilhaRequest
+	if !h.decodificarValidar(w, r, &req) {
+		return
+	}
+	resp, err := h.criar.Execute(r.Context(), req)
+	if err != nil {
+		h.escreverErro(w, err)
+		return
+	}
+	h.escreverJSON(w, http.StatusCreated, resp)
+}
+
+func (h *TrilhaHandler) Obter(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.obter.Execute(r.Context(), chi.URLParam(r, "slug"))
+	if err != nil {
+		h.escreverErro(w, err)
+		return
+	}
+	h.escreverJSON(w, http.StatusOK, resp)
+}
+
+func (h *TrilhaHandler) Listar(w http.ResponseWriter, r *http.Request) {
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	resp, err := h.listar.Execute(r.Context(), limit, offset)
+	if err != nil {
+		h.escreverErro(w, err)
+		return
+	}
+	h.escreverJSON(w, http.StatusOK, resp)
+}
+
+func (h *TrilhaHandler) AdicionarModulo(w http.ResponseWriter, r *http.Request) {
+	var req dto.AdicionarModuloRequest
+	if !h.decodificarValidar(w, r, &req) {
+		return
+	}
+	resp, err := h.adicionar.Execute(r.Context(), chi.URLParam(r, "id"), req)
+	if err != nil {
+		h.escreverErro(w, err)
+		return
+	}
+	h.escreverJSON(w, http.StatusCreated, resp)
+}
+
+func (h *TrilhaHandler) Publicar(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.publicar.Execute(r.Context(), chi.URLParam(r, "id"))
+	if err != nil {
+		h.escreverErro(w, err)
+		return
+	}
+	h.escreverJSON(w, http.StatusOK, resp)
+}
+
+func (h *TrilhaHandler) decodificarValidar(w http.ResponseWriter, r *http.Request, dst any) bool {
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		h.escreverJSON(w, http.StatusBadRequest, map[string]string{"erro": "corpo da requisição inválido"})
+		return false
+	}
+	if err := h.validate.Struct(dst); err != nil {
+		h.escreverJSON(w, http.StatusUnprocessableEntity, map[string]string{"erro": err.Error()})
+		return false
+	}
+	return true
+}
+
+func (h *TrilhaHandler) escreverJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func (h *TrilhaHandler) escreverErro(w http.ResponseWriter, err error) {
+	var de *domainErros.DomainError
+	if !errors.As(err, &de) {
+		h.escreverJSON(w, http.StatusInternalServerError, map[string]string{"erro": "erro interno"})
+		return
+	}
+	status := http.StatusInternalServerError
+	switch de.Kind {
+	case domainErros.InvalidArgument:
+		status = http.StatusBadRequest
+	case domainErros.NotFound:
+		status = http.StatusNotFound
+	case domainErros.AlreadyExists:
+		status = http.StatusConflict
+	case domainErros.Unauthorized:
+		status = http.StatusUnauthorized
+	case domainErros.Forbidden:
+		status = http.StatusForbidden
+	case domainErros.InvalidState:
+		status = http.StatusConflict
+	}
+	h.escreverJSON(w, status, map[string]string{"erro": de.Message})
+}

--- a/estudos-platform/backend-platform/internal/presentation/http/router/router.go
+++ b/estudos-platform/backend-platform/internal/presentation/http/router/router.go
@@ -28,6 +28,7 @@ func New(cfg *config.Config, pool *pgxpool.Pool) http.Handler {
 	// ---- repositórios (infra) ----
 	usuarioRepo := pgrepo.NewUsuarioRepoPG(pool)
 	refreshRepo := pgrepo.NewRefreshTokenRepoPG(pool)
+	trilhaRepo := pgrepo.NewTrilhaRepoPG(pool)
 
 	// ---- ports concretos (infra) ----
 	hasher := external.NewBcryptHasher(10)
@@ -45,18 +46,30 @@ func New(cfg *config.Config, pool *pgxpool.Pool) http.Handler {
 	refreshUC := usecase.NewRefreshTokenUC(refreshRepo, usuarioRepo, tokens, tokenCfg)
 	perfilUC := usecase.NewObterPerfil(usuarioRepo)
 
-	// ---- handler (apresentação) ----
+	criarTrilhaUC := usecase.NewCriarTrilha(trilhaRepo)
+	obterTrilhaUC := usecase.NewObterTrilha(trilhaRepo)
+	listarTrilhasUC := usecase.NewListarTrilhas(trilhaRepo)
+	adicionarModuloUC := usecase.NewAdicionarModulo(trilhaRepo)
+	publicarTrilhaUC := usecase.NewPublicarTrilha(trilhaRepo)
+
+	// ---- handlers (apresentação) ----
 	auth := handler.NewAuthHandler(registrarUC, loginUC, refreshUC, perfilUC)
+	trilhas := handler.NewTrilhaHandler(criarTrilhaUC, obterTrilhaUC, listarTrilhasUC, adicionarModuloUC, publicarTrilhaUC)
 
 	r.Route("/api/v1", func(api chi.Router) {
 		api.Post("/auth/registrar", auth.Registrar)
 		api.Post("/auth/login", auth.Login)
 		api.Post("/auth/refresh", auth.Refresh)
 
-		// grupo protegido por JWT
+		api.Get("/trilhas", trilhas.Listar)
+		api.Get("/trilhas/{slug}", trilhas.Obter)
+
 		api.Group(func(pr chi.Router) {
 			pr.Use(middleware.NewAutenticador(tokens).Proteger)
 			pr.Get("/auth/me", auth.Me)
+			pr.Post("/trilhas", trilhas.Criar)
+			pr.Post("/trilhas/{id}/modulos", trilhas.AdicionarModulo)
+			pr.Post("/trilhas/{id}/publicar", trilhas.Publicar)
 		})
 	})
 

--- a/estudos-platform/bruno/00-health/health.bru
+++ b/estudos-platform/bruno/00-health/health.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Health
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/health
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body: eq ok
+}
+
+docs {
+  Smoke test. A API precisa estar no ar (`go run ./cmd/api`).
+}

--- a/estudos-platform/bruno/01-auth/01-registrar.bru
+++ b/estudos-platform/bruno/01-auth/01-registrar.bru
@@ -1,0 +1,42 @@
+meta {
+  name: Registrar
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/v1/auth/registrar
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "nome": "{{nome}}",
+    "email": "{{email}}",
+    "senha": "{{senha}}"
+  }
+}
+
+script:post-response {
+  const body = res.getBody();
+  if (body && body.tokens) {
+    bru.setEnvVar("accessToken", body.tokens.access_token);
+    bru.setEnvVar("refreshToken", body.tokens.refresh_token);
+    bru.setEnvVar("usuarioId", body.usuario.id);
+  }
+}
+
+assert {
+  res.status: eq 201
+}
+
+docs {
+  Cria usuário e salva access/refresh no environment Local.
+  Se o e-mail já existir, retorna 409 — use Login ou mude `email` no env.
+  Na branch com PR #5 o refresh fica persistido no banco.
+}

--- a/estudos-platform/bruno/01-auth/02-login.bru
+++ b/estudos-platform/bruno/01-auth/02-login.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Login
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/v1/auth/login
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "email": "{{email}}",
+    "senha": "{{senha}}"
+  }
+}
+
+script:post-response {
+  const body = res.getBody();
+  if (body && body.tokens) {
+    bru.setEnvVar("accessToken", body.tokens.access_token);
+    bru.setEnvVar("refreshToken", body.tokens.refresh_token);
+    bru.setEnvVar("usuarioId", body.usuario.id);
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+docs {
+  Autentica e atualiza os tokens no environment.
+  Rode este request antes dos endpoints protegidos se o access tiver expirado.
+}

--- a/estudos-platform/bruno/01-auth/03-me.bru
+++ b/estudos-platform/bruno/01-auth/03-me.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Me
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/v1/auth/me
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+assert {
+  res.status: eq 200
+}
+
+docs {
+  Retorna o perfil do usuário autenticado.
+  Precisa de accessToken (rode Login ou Registrar antes).
+}

--- a/estudos-platform/bruno/01-auth/04-refresh.bru
+++ b/estudos-platform/bruno/01-auth/04-refresh.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Refresh
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/api/v1/auth/refresh
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "refresh_token": "{{refreshToken}}"
+  }
+}
+
+script:post-response {
+  const body = res.getBody();
+  if (body && body.tokens) {
+    bru.setEnvVar("accessToken", body.tokens.access_token);
+    bru.setEnvVar("refreshToken", body.tokens.refresh_token);
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+docs {
+  Rotaciona o par de tokens. O refresh antigo deixa de valer.
+}

--- a/estudos-platform/bruno/01-auth/05-logout.bru
+++ b/estudos-platform/bruno/01-auth/05-logout.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Logout
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/api/v1/auth/logout
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+script:post-response {
+  if (res.getStatus() === 200) {
+    bru.setEnvVar("refreshToken", "");
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+docs {
+  Requer PR #7 mergeado (`POST /auth/logout`).
+  Revoga todos os refresh tokens do usuário.
+  Depois do logout, Refresh deve falhar com 401.
+}

--- a/estudos-platform/bruno/02-trilhas/01-criar.bru
+++ b/estudos-platform/bruno/02-trilhas/01-criar.bru
@@ -1,0 +1,44 @@
+meta {
+  name: Criar Trilha
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/v1/trilhas
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "titulo": "Go Básico",
+    "descricao": "Fundamentos de Go para a plataforma de estudos",
+    "slug": "{{trilhaSlug}}"
+  }
+}
+
+script:post-response {
+  const body = res.getBody();
+  if (body && body.id) {
+    bru.setEnvVar("trilhaId", body.id);
+    bru.setEnvVar("trilhaSlug", body.slug);
+  }
+}
+
+assert {
+  res.status: eq 201
+}
+
+docs {
+  Cria trilha (rascunho / não publicada). Salva `trilhaId` e `trilhaSlug` no env.
+  Se o slug já existir → 409; mude `trilhaSlug` no environment Local.
+}

--- a/estudos-platform/bruno/02-trilhas/02-adicionar-modulo.bru
+++ b/estudos-platform/bruno/02-trilhas/02-adicionar-modulo.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Adicionar Modulo
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/v1/trilhas/{{trilhaId}}/modulos
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "titulo": "Structs e Interfaces",
+    "descricao": "Tipos, methods e contratos em Go",
+    "slug": "structs-e-interfaces"
+  }
+}
+
+assert {
+  res.status: eq 201
+}
+
+docs {
+  Adiciona módulo à trilha. Exige `trilhaId` (rode Criar Trilha antes).
+  Trilha sem módulo não pode ser publicada.
+}

--- a/estudos-platform/bruno/02-trilhas/03-publicar.bru
+++ b/estudos-platform/bruno/02-trilhas/03-publicar.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Publicar Trilha
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/v1/trilhas/{{trilhaId}}/publicar
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+assert {
+  res.status: eq 200
+}
+
+docs {
+  Publica a trilha. Depois disso ela aparece no Listar / Obter por slug.
+}

--- a/estudos-platform/bruno/02-trilhas/04-listar.bru
+++ b/estudos-platform/bruno/02-trilhas/04-listar.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Listar Trilhas
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/v1/trilhas?limit=20&offset=0
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+}
+
+docs {
+  Lista apenas trilhas publicadas (público, sem token).
+}

--- a/estudos-platform/bruno/02-trilhas/05-obter.bru
+++ b/estudos-platform/bruno/02-trilhas/05-obter.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Obter Trilha
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/api/v1/trilhas/{{trilhaSlug}}
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+}
+
+docs {
+  Detalhe da trilha publicada + módulos. 404 se não estiver publicada.
+}

--- a/estudos-platform/bruno/03-artigos/01-criar.bru
+++ b/estudos-platform/bruno/03-artigos/01-criar.bru
@@ -1,0 +1,54 @@
+meta {
+  name: Criar Artigo
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/v1/artigos
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "titulo": "DDD na Prática",
+    "subtitulo": "Aggregates, VOs e bounded contexts em Go",
+    "slug": "{{artigoSlug}}",
+    "conteudo": {
+      "blocks": [
+        { "type": "heading", "text": "Introdução" },
+        { "type": "paragraph", "text": "Como modelamos o domínio no Estudos Platform." }
+      ]
+    },
+    "metadados": {
+      "tempo_leitura_min": 8,
+      "tags": ["ddd", "go", "arquitetura"]
+    }
+  }
+}
+
+script:post-response {
+  const body = res.getBody();
+  if (body && body.id) {
+    bru.setEnvVar("artigoId", body.id);
+    bru.setEnvVar("artigoSlug", body.slug);
+  }
+}
+
+assert {
+  res.status: eq 201
+}
+
+docs {
+  Requer PR #8 mergeado (CRUD artigos).
+  Cria rascunho e salva `artigoId` / `artigoSlug` no env.
+}

--- a/estudos-platform/bruno/03-artigos/02-atualizar.bru
+++ b/estudos-platform/bruno/03-artigos/02-atualizar.bru
@@ -1,0 +1,44 @@
+meta {
+  name: Atualizar Artigo
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{baseUrl}}/api/v1/artigos/{{artigoId}}
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "titulo": "DDD na Prática (atualizado)",
+    "subtitulo": "Aggregates, VOs e bounded contexts em Go",
+    "conteudo": {
+      "blocks": [
+        { "type": "heading", "text": "Introdução" },
+        { "type": "paragraph", "text": "Conteúdo revisado para publicação." }
+      ]
+    },
+    "metadados": {
+      "tempo_leitura_min": 10,
+      "tags": ["ddd", "go"]
+    }
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+docs {
+  Só o autor consegue atualizar (Bearer do criador).
+}

--- a/estudos-platform/bruno/03-artigos/03-publicar.bru
+++ b/estudos-platform/bruno/03-artigos/03-publicar.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Publicar Artigo
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/v1/artigos/{{artigoId}}/publicar
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+assert {
+  res.status: eq 200
+}
+
+docs {
+  Publica o artigo. Depois aparece no Listar / Obter por slug.
+}

--- a/estudos-platform/bruno/03-artigos/04-listar.bru
+++ b/estudos-platform/bruno/03-artigos/04-listar.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Listar Artigos
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/v1/artigos?limit=20&offset=0
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+}
+
+docs {
+  Lista apenas artigos publicados (público).
+}

--- a/estudos-platform/bruno/03-artigos/05-obter.bru
+++ b/estudos-platform/bruno/03-artigos/05-obter.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Obter Artigo
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/api/v1/artigos/{{artigoSlug}}
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+}
+
+docs {
+  Detalhe do artigo publicado por slug.
+}

--- a/estudos-platform/bruno/README.md
+++ b/estudos-platform/bruno/README.md
@@ -1,0 +1,48 @@
+# Collection Bruno — Estudos Platform API
+
+Collection para testar a API no [Bruno](https://www.usebruno.com/) (alternativa open-source ao Postman).
+
+## Como abrir
+
+1. Instale o Bruno: https://www.usebruno.com/downloads  
+2. **Open Collection** → selecione a pasta:
+   ```
+   estudos-platform/bruno
+   ```
+3. Em cima, escolha o environment **Local**
+4. Suba a API (`docker compose up -d` + `go run ./cmd/api` em `backend-platform`)
+
+## Ordem sugerida de execução
+
+| # | Pasta | Request | Observação |
+|---|--------|---------|------------|
+| 1 | `00-health` | Health | Tem que retornar `ok` |
+| 2 | `01-auth` | Registrar **ou** Login | Salva tokens no env |
+| 3 | `01-auth` | Me | Precisa de Bearer |
+| 4 | `01-auth` | Refresh | Rotaciona tokens |
+| 5 | `02-trilhas` | Criar → Módulo → Publicar → Listar → Obter | Branch com trilhas |
+| 6 | `03-artigos` | Criar → Atualizar → Publicar → Listar → Obter | Precisa do PR #8 |
+| 7 | `01-auth` | Logout | Precisa do PR #7 |
+
+## Variáveis (environment Local)
+
+| Var | Uso |
+|-----|-----|
+| `baseUrl` | `http://localhost:8080` |
+| `email` / `senha` / `nome` | Credenciais de teste |
+| `accessToken` / `refreshToken` | Preenchidos após Login/Registrar |
+| `trilhaId` / `trilhaSlug` | Preenchidos após Criar Trilha |
+| `artigoId` / `artigoSlug` | Preenchidos após Criar Artigo |
+
+Se **Registrar** der `409` (e-mail já cadastrado), rode **Login** ou mude o `email` no environment.
+
+## Compatibilidade por branch/PR
+
+| Feature | Status |
+|---------|--------|
+| Health + Auth (registrar/login/refresh/me) | Base `dev` / sprint 1 |
+| Logout | PR #7 |
+| Trilhas | PR #9 / branch `feat/trilhas-modulos` |
+| Artigos | PR #8 / branch `feat/artigos-crud` |
+
+Requests de feature ainda não mergeada vão retornar **404** — normal até o merge.

--- a/estudos-platform/bruno/bruno.json
+++ b/estudos-platform/bruno/bruno.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "name": "Estudos Platform API",
+  "type": "collection",
+  "ignore": ["node_modules", ".git"]
+}

--- a/estudos-platform/bruno/environments/Local.bru
+++ b/estudos-platform/bruno/environments/Local.bru
@@ -1,0 +1,13 @@
+vars {
+  baseUrl: http://localhost:8080
+  email: bruno.teste@estudos.local
+  senha: senha1234
+  nome: Bruno Teste
+  accessToken: 
+  refreshToken: 
+  usuarioId: 
+  trilhaId: 
+  trilhaSlug: go-basico
+  artigoId: 
+  artigoSlug: ddd-na-pratica
+}

--- a/estudos-platform/docs/AULA-CODE-REVIEW-GO-SPRINT.md
+++ b/estudos-platform/docs/AULA-CODE-REVIEW-GO-SPRINT.md
@@ -1,0 +1,724 @@
+# Aula — Code Review do Backend Go (Estudos Platform)
+
+Documento didático para explicar o que construímos no MVP, como ler os PRs e a **sintaxe Go** por trás de cada decisão.
+
+| Item | Valor |
+|------|--------|
+| Projeto | `estudos-platform/backend-platform` |
+| Linguagem | Go 1.26 |
+| Arquitetura | DDD em camadas + vertical slice |
+| Branch base | `dev` |
+| Repositório | [Thiago-Tertuliano/MVP-Proj](https://github.com/Thiago-Tertuliano/MVP-Proj) |
+
+---
+
+## 1. O que é este projeto (em uma frase)
+
+API HTTP em Go para uma plataforma de estudos de TI: autenticação JWT, artigos com conteúdo JSONB e trilhas com módulos — tudo organizado em Domain-Driven Design.
+
+---
+
+## 2. Mapa mental das camadas (DDD)
+
+```
+Presentation  →  Application  →  Domain  ←  Infrastructure
+   (HTTP)         (use cases)    (puro)      (Postgres, JWT, bcrypt)
+```
+
+| Pasta | Responsabilidade | Pode importar |
+|-------|------------------|---------------|
+| `internal/domain/` | Regras de negócio, entidades, VOs, interfaces de repo | stdlib (+ uuid) |
+| `internal/applications/` | Orquestra casos de uso, DTOs, ports | domain |
+| `internal/infrastructure/` | SQL, JWT, bcrypt, config | domain (+ libs externas) |
+| `internal/presentation/` | Handlers HTTP, middleware, router | applications (DTOs/use cases) |
+| `cmd/api/` | `main` — sobe o servidor e faz DI | infrastructure + presentation |
+
+**Regra de ouro (Dependency Rule):** dependências apontam para **dentro**. O domínio nunca importa HTTP, SQL ou JWT.
+
+### Por que `internal/`?
+
+Em Go, o diretório `internal/` é especial: **só o próprio módulo** pode importar pacotes dentro dele. É encapsulamento no nível do módulo — ninguém de fora do repo consegue importar `.../internal/domain/...`.
+
+---
+
+## 3. Sintaxe Go — guia rápido para a aula
+
+Use esta seção como “dicionário” enquanto revisa o código.
+
+### 3.1 Pacotes e arquivos
+
+```go
+package entity   // todo arquivo .go na pasta declara o mesmo package
+
+import (
+    "fmt"                                    // stdlib
+    "github.com/google/uuid"                 // externo (go.mod)
+    ".../internal/domain/shared/errors"      // interno do módulo
+)
+```
+
+- Um diretório = um pacote (em geral).
+- Nome exportado começa com **maiúscula** (`Usuario`, `NewEmail`).
+- Nome privado começa com **minúscula** (`nome`, `normalizeSlug`).
+
+### 3.2 Struct, campos e métodos
+
+```go
+type Usuario struct {
+    nome  string              // privado
+    email valueobject.Email   // VO embutido
+}
+
+// Método com receiver por valor (não altera o struct original)
+func (u Usuario) Nome() string { return u.nome }
+
+// Método com receiver por ponteiro (pode alterar)
+func (u *Usuario) AlterarSenha(h valueobject.SenhaHash) {
+    u.senhaHash = h
+}
+```
+
+**Ponteiro `*T` vs valor `T`:**
+
+| Receiver | Quando usar |
+|----------|-------------|
+| `*Usuario` | Precisa mutar o estado |
+| `Usuario` | Só lê; cópia barata (structs pequenas) |
+
+### 3.3 Embedding (composição)
+
+Go **não tem herança de classes**. Tem *embedding*:
+
+```go
+type Usuario struct {
+    kernel.BaseEntity  // embed: Usuario “ganha” ID(), CreatedAt(), Touch()
+    nome string
+}
+```
+
+Em aula: “é como composição automática — os métodos de `BaseEntity` sobem para `Usuario`”.
+
+### 3.4 Interfaces (contratos)
+
+```go
+type TokenGerador interface {
+    Gerar(claims Claims, accessTTL, refreshTTL time.Duration) (*TokenPar, error)
+    ValidarAccessToken(token string) (*Claims, error)
+}
+```
+
+- Interfaces são **satisfeitas implicitamente** (não existe `implements`).
+- Qualquer tipo com esses métodos vira `TokenGerador`.
+- Por isso dá para mockar nos testes sem frameworks pesados.
+
+### 3.5 Múltiplos retornos e `error`
+
+```go
+func NewEmail(raw string) (Email, error) {
+    // ...
+    return Email{}, errors.ErrInvalidArgument("email inválido", "...", nil)
+}
+```
+
+Idioma Go: último retorno costuma ser `error`. Caller sempre verifica:
+
+```go
+email, err := valueobject.NewEmail(req.Email)
+if err != nil {
+    return nil, err
+}
+```
+
+### 3.6 `errors.As` / `errors.Is` (Go 1.13+)
+
+```go
+var de *errors.DomainError
+if stderrors.As(err, &de) && de.Kind == errors.NotFound {
+    // trata NotFound
+}
+```
+
+`As` “desembrulha” a cadeia de erros até achar o tipo. Combinamos com `Unwrap()` no `DomainError`.
+
+### 3.7 `context.Context`
+
+Quase toda função de I/O recebe `ctx context.Context` **como primeiro parâmetro**:
+
+```go
+func (uc *LoginUsuario) Execute(ctx context.Context, req dto.LoginRequest) (*dto.AuthResponse, error)
+```
+
+Serve para cancelamento, timeout e valores de request (ex.: `usuario_id` no middleware).
+
+### 3.8 Goroutines e channels (só no `main`)
+
+```go
+go func() {
+    srv.ListenAndServe()  // roda em paralelo
+}()
+
+quit := make(chan os.Signal, 1)
+signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+<-quit  // bloqueia até Ctrl+C
+```
+
+Em aula: “`go` dispara concorrência; `chan` sincroniza o shutdown gracioso”.
+
+### 3.9 Testes
+
+Arquivo `*_test.go` no mesmo pacote:
+
+```go
+func TestLogin_Sucesso(t *testing.T) {
+    // arrange → act → assert
+    if err != nil {
+        t.Fatalf("não deveria retornar erro: %v", err)
+    }
+}
+```
+
+Rodar: `go test ./internal/... -count=1`
+
+---
+
+## 4. Base já existente (Sprint 1 — Auth)
+
+Antes dos PRs #5–#9, o backend já tinha o vertical slice de autenticação.
+
+### 4.1 Entry point — `cmd/api/main.go`
+
+**O que faz:** carrega config, abre pool Postgres, sobe `http.Server`, espera sinal e faz `Shutdown` com timeout.
+
+**Pontos para a aula:**
+
+1. `defer pool.Close()` — cleanup garantido ao sair da função.
+2. Timeouts no server (`ReadTimeout`, `WriteTimeout`) — proteção contra conexões lentas.
+3. Graceful shutdown — não corta request no meio.
+
+### 4.2 Entidade `Usuario` — encapsulamento
+
+```go
+type Usuario struct {
+    kernel.BaseEntity
+    nome      string                 // minúsculo = privado ao pacote
+    email     valueobject.Email
+    senhaHash valueobject.SenhaHash
+    status    StatusConta
+}
+```
+
+**Code review (positivo):**
+
+- Campos privados + getters públicos → ninguém de fora muda `email` sem passar por regra.
+- `NovoUsuario` valida na construção (factory).
+- `ReconstruirUsuario` separa “criar novo” de “hidratar do banco” — padrão clássico em DDD + Go.
+
+**Sintaxe:** `type StatusConta string` é um *defined type* — tipagem forte sobre `string` (não mistura com qualquer string sem conversão).
+
+### 4.3 Value Object `Email`
+
+```go
+func NewEmail(raw string) (Email, error) {
+    raw = strings.TrimSpace(strings.ToLower(raw))
+    // valida com net/mail
+    return Email{value: raw}, nil
+}
+```
+
+VO = imutável, igualdade por valor, validação na criação. Em Go isso vira struct pequena + construtor.
+
+### 4.4 Ports (inversão de dependência)
+
+```go
+// application/port
+type SenhaHasher interface {
+    Hash(plain string) (string, error)
+    Comparar(hash, plain string) bool
+}
+```
+
+Use case depende da **interface**; `bcrypt_hasher.go` na infra implementa. Trocar bcrypt por argon2 = mudar só a infra.
+
+### 4.5 `DomainError` → HTTP
+
+```go
+switch de.Kind {
+case domainErros.InvalidArgument:
+    status = http.StatusBadRequest      // 400
+case domainErros.AlreadyExists:
+    status = http.StatusConflict        // 409
+case domainErros.Unauthorized:
+    status = http.StatusUnauthorized    // 401
+}
+```
+
+O domínio fala em linguagem de negócio (`AlreadyExists`); a presentation traduz para HTTP. Domínio **não** conhece status codes.
+
+### 4.6 Endpoints da Sprint 1
+
+| Método | Rota | Auth? | Função |
+|--------|------|-------|--------|
+| POST | `/api/v1/auth/registrar` | Não | Cria usuário + tokens |
+| POST | `/api/v1/auth/login` | Não | Valida senha + tokens |
+| POST | `/api/v1/auth/refresh` | Não | Rotaciona refresh |
+| GET | `/api/v1/auth/me` | Bearer | Perfil do token |
+
+**Detalhe de segurança (aula):** no login, usuário inexistente e senha errada retornam a **mesma** mensagem (`credenciais inválidas`) — anti-enumeração de e-mails.
+
+**Refresh:** o token em texto puro **nunca** vai para o banco; só o hash SHA-256.
+
+---
+
+## 5. PRs abertos — code review didático
+
+Ordem sugerida de merge (e de apresentação na aula): **#5 → #6 → #7 → #8 → #9**.
+
+---
+
+### PR #5 — `fix(auth): persiste refresh token no registro`
+
+🔗 https://github.com/Thiago-Tertuliano/MVP-Proj/pull/5  
+Branch: `feat/auth-register-persist-refresh`
+
+#### Problema
+
+O login salvava o refresh no Postgres. O register gerava o token na resposta, mas **não persistia**. Resultado: usuário se registra → chama `/auth/refresh` → 401.
+
+#### O que mudou
+
+`RegistrarUsuario` passou a receber `RefreshTokenRepository` (mesmo fluxo do login):
+
+```go
+type RegistrarUsuario struct {
+    repo    repository.UsuarioRepository
+    refresh repository.RefreshTokenRepository  // novo
+    hasher  port.SenhaHasher
+    tokens  port.TokenGerador
+    cfg     RegistrarConfig
+}
+```
+
+Depois de `Gerar(...)`:
+
+```go
+tokenHash := sha256.Sum256([]byte(tokens.RefreshToken))
+rt := &repository.RefreshToken{
+    ID:        uuid.New().String(),
+    UsuarioID: usuario.ID().String(),
+    TokenHash: hex.EncodeToString(tokenHash[:]),
+    ExpiraEm:  tokens.RefreshExp,
+}
+uc.refresh.Save(ctx, rt)
+```
+
+#### Sintaxe em destaque
+
+- `sha256.Sum256` retorna `[32]byte` (array). `hash[:]` vira slice para `hex.EncodeToString`.
+- Injeção via construtor `NewRegistrarUsuario(...)` — Composition Root no `router.go`.
+
+#### Code review
+
+| ✅ Bom | ⚠️ Observação |
+|--------|----------------|
+| Paridade login/register | Register ainda não é atômico (salva user, depois token). Falha no 2º passo deixa user sem refresh — aceitável no MVP |
+| Teste cobre “refresh foi salvo” | — |
+
+**Pergunta para a turma:** por que hashear o refresh e não guardar o JWT cru?
+
+---
+
+### PR #6 — `feat(http): adiciona middleware CORS`
+
+🔗 https://github.com/Thiago-Tertuliano/MVP-Proj/pull/6  
+Branch: `feat/http-cors-middleware`
+
+#### Problema
+
+Frontend (Next/Vite em `localhost:3000`) seria bloqueado pelo browser sem CORS.
+
+#### O que mudou
+
+Middleware próprio (sem lib extra):
+
+```go
+type CORS struct {
+    allowedOrigins map[string]struct{}  // set idiomático em Go
+    allowAll       bool
+}
+
+func (c *CORS) Handler(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        // seta headers se Origin permitida
+        if r.Method == http.MethodOptions {
+            w.WriteHeader(http.StatusNoContent) // preflight
+            return
+        }
+        next.ServeHTTP(w, r)
+    })
+}
+```
+
+Config via env:
+
+```env
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+```
+
+#### Sintaxe em destaque
+
+**`map[string]struct{}` como set**
+
+```go
+allowedOrigins map[string]struct{}
+c.allowedOrigins[o] = struct{}{}  // valor vazio ocupa 0 bytes
+_, ok := c.allowedOrigins[origin]
+```
+
+Em Go não existe `Set<T>` nativo; esse padrão é o idiomático.
+
+**Closure que captura `next`:**
+
+```go
+return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    // ...
+    next.ServeHTTP(w, r)
+})
+```
+
+`http.HandlerFunc` é um *adapter*: converte `func(ResponseWriter, *Request)` em `http.Handler`.
+
+**Chain no Chi:**
+
+```go
+r.Use(middleware.RequestID)
+r.Use(middleware.Recovery)
+r.Use(middleware.NewCORS(cfg.CORSAllowedOrigins).Handler)
+```
+
+Ordem importa: Recovery por fora evita panic sem resposta; CORS cedo para preflight.
+
+#### Code review
+
+| ✅ Bom | ⚠️ Observação |
+|--------|----------------|
+| Allowlist explícita | `*` + `Allow-Credentials: true` ecoa a Origin (correto); não usar `*` em produção |
+| Testes de origem permitida/negada/preflight | — |
+
+---
+
+### PR #7 — `feat(auth): endpoint POST /auth/logout`
+
+🔗 https://github.com/Thiago-Tertuliano/MVP-Proj/pull/7  
+Branch: `feat/auth-logout`
+
+#### O que faz
+
+Rota **protegida** `POST /api/v1/auth/logout`:
+
+1. Middleware JWT coloca `usuario_id` no `context`.
+2. Use case chama `RevokeAllByUser`.
+3. Todos os refresh daquele usuário ficam `revogado = true`.
+
+```go
+func (uc *LogoutUsuario) Execute(ctx context.Context, usuarioID string) error {
+    id, err := uuid.Parse(usuarioID)
+    if err != nil {
+        return errors.ErrInvalidArgument("usuario_id inválido", "...", err)
+    }
+    return uc.refresh.RevokeAllByUser(ctx, id)
+}
+```
+
+No handler:
+
+```go
+usuarioID, _ := r.Context().Value(middleware.CtxUsuarioID).(string)
+```
+
+#### Sintaxe em destaque
+
+**Type assertion**
+
+```go
+usuarioID, _ := r.Context().Value(middleware.CtxUsuarioID).(string)
+```
+
+`Value` retorna `any` (`interface{}`). `(string)` tenta converter. O `_` ignora o `ok` — em produção cuidadosa, checar `ok`.
+
+**Typed context key** (em `middleware`):
+
+```go
+type ctxKey string
+const CtxUsuarioID ctxKey = "usuario_id"
+```
+
+Evita colisão com outras libs que usem a mesma string como key.
+
+#### Code review
+
+| ✅ Bom | ⚠️ Observação |
+|--------|----------------|
+| Logout server-side (não só apagar token no client) | Access JWT continua válido até expirar (TTL curto mitiga; denylist seria overkill no MVP) |
+| Handler e use case testados | — |
+
+**Pergunta para a turma:** logout invalida o access token imediatamente? Por quê (não)?
+
+---
+
+### PR #8 — `feat(artigos): CRUD de artigos com publicação`
+
+🔗 https://github.com/Thiago-Tertuliano/MVP-Proj/pull/8  
+Branch: `feat/artigos-crud`
+
+#### Escopo
+
+| Camada | Peças |
+|--------|--------|
+| Domain | `Artigo`, `Slug`, `ArtigoStatus` |
+| Application | Criar, Obter, Listar, Atualizar, Publicar |
+| Infra | Migration `0002`, `ArtigoRepoPG` |
+| HTTP | Handler + rotas públicas/protegidas |
+
+#### Endpoints
+
+| Método | Rota | Auth | Comportamento |
+|--------|------|------|---------------|
+| GET | `/artigos` | Não | Lista publicados |
+| GET | `/artigos/{slug}` | Não | Detalhe publicado |
+| POST | `/artigos` | Sim | Cria rascunho |
+| PUT | `/artigos/{id}` | Sim | Atualiza (só autor) |
+| POST | `/artigos/{id}/publicar` | Sim | Publica (só autor) |
+
+#### Domínio — regras no aggregate
+
+```go
+func (a *Artigo) Publicar() error {
+    if a.status != Revisao && a.status != Rascunho {
+        return errors.ErrInvalidState(...)
+    }
+    if conteudo vazio {
+        return errors.ErrInvalidArgument(...)
+    }
+    a.status = Publicado
+    now := time.Now().UTC()
+    a.publicadoEm = &now  // *time.Time — nil quando não publicado
+    a.Touch()
+    return nil
+}
+```
+
+**Sintaxe:** `*time.Time` diferencia “sem data” (`nil`) de “zero value” (`0001-01-01`). Em JSON vira `publicado_em` omitido ou unix timestamp.
+
+#### VO `Slug`
+
+```go
+func NewSlug(raw string) (Slug, error) {
+    normalized := normalizeSlug(raw) // lower, acentos, hífens
+    if !slugPattern.MatchString(normalized) {
+        return Slug{}, errors.ErrInvalidArgument(...)
+    }
+    return Slug{value: normalized}, nil
+}
+```
+
+Criar artigo sem `slug` no body → deriva do título (`Arquitetura Hexagonal` → `arquitetura-hexagonal`).
+
+#### Conteúdo JSONB
+
+```go
+conteudo json.RawMessage  // []byte que é JSON válido
+```
+
+`encoding/json.RawMessage` adia o parse — o domínio não precisa conhecer o schema dos blocks (Notion-style). Postgres guarda como `JSONB`.
+
+#### Autorização no use case
+
+```go
+if !artigo.EhAutor(autorUUID) {
+    return nil, errors.ErrForbidden("apenas o autor pode editar o artigo", "...", nil)
+}
+```
+
+Handler só extrai ID do token; a regra “só o autor” fica na aplicação/domínio.
+
+#### Chi — path params
+
+```go
+slug := chi.URLParam(r, "slug")
+id := chi.URLParam(r, "id")
+```
+
+Rotas registradas no composition root (`router.New`).
+
+#### Code review
+
+| ✅ Bom | ⚠️ Observação |
+|--------|----------------|
+| Aggregate rico (não é anêmico) | Publicar aceita rascunho direto (README original pedia só revisão — simplificação de MVP) |
+| Listagem só de publicados | Sem paginação cursor; limit/offset simples |
+| Upsert no Save (`ON CONFLICT`) | Embedding/pgvector ainda não — próximo sprint |
+
+**Pergunta para a turma:** por que `GET` por slug é público e `PUT` por id exige auth?
+
+---
+
+### PR #9 — `feat(trilhas): CRUD de trilhas e módulos`
+
+🔗 https://github.com/Thiago-Tertuliano/MVP-Proj/pull/9  
+Branch: `feat/trilhas-modulos`
+
+#### Escopo
+
+Aggregate `Trilha` contendo entidades filhas `Modulo` (não são aggregate roots).
+
+```go
+type Trilha struct {
+    kernel.BaseEntity
+    slug      valueobject.Slug
+    publicada bool
+    modulos   []*Modulo
+}
+
+func (t *Trilha) AdicionarModulo(...) (*Modulo, error) { ... }
+func (t *Trilha) Publicar() error {
+    if len(t.modulos) == 0 {
+        return errors.ErrInvalidState("trilha sem módulos não pode ser publicada", ...)
+    }
+    t.publicada = true
+    return nil
+}
+```
+
+#### Endpoints
+
+| Método | Rota | Auth | Função |
+|--------|------|------|--------|
+| GET | `/trilhas` | Não | Lista publicadas |
+| GET | `/trilhas/{slug}` | Não | Detalhe + módulos |
+| POST | `/trilhas` | Sim | Cria |
+| POST | `/trilhas/{id}/modulos` | Sim | Adiciona módulo |
+| POST | `/trilhas/{id}/publicar` | Sim | Publica |
+
+#### Persistência transacional
+
+No `TrilhaRepoPG.Save`:
+
+```go
+tx, err := r.pool.Begin(ctx)
+defer tx.Rollback(ctx)          // no-op se já Commitou
+
+// UPSERT trilha
+// DELETE FROM modulos WHERE trilha_id = ...
+// INSERT de cada módulo
+
+return tx.Commit(ctx)
+```
+
+**Por quê?** Módulos vivem dentro do aggregate. Regravar = substituir a coleção inteira na mesma transação (consistência).
+
+#### Sintaxe em destaque
+
+- `defer tx.Rollback(ctx)` é padrão seguro com pgx.
+- Slice `[]*Modulo` — ponteiros para evitar cópia grande e permitir mutação.
+
+#### Code review
+
+| ✅ Bom | ⚠️ Observação |
+|--------|----------------|
+| Invariante “sem módulo → não publica” | Ainda **não** liga artigo ↔ trilha/módulo (FK fica para depois) |
+| VO `Slug` incluído nesta PR | Mesmo arquivo existe no PR #8 → conflito trivial no merge |
+| — | `router.go` e `Makefile` conflitam com #8 — unir rotas e migrations 0002+0003 |
+
+**Pergunta para a turma:** módulo é aggregate root? Por que não?
+
+---
+
+## 6. Fluxo ponta a ponta (desenhar no quadro)
+
+```
+Cliente
+  │  POST /api/v1/artigos  + Authorization: Bearer …
+  ▼
+Middleware Auth  →  valida JWT → context(usuario_id)
+  ▼
+ArtigoHandler.Criar  →  decode JSON + validator
+  ▼
+CriarArtigo.Execute  →  NewSlug, NovoArtigo, repo.Save
+  ▼
+ArtigoRepoPG  →  INSERT JSONB no Postgres
+  ▼
+201 + ArtigoResponse (DTO)
+```
+
+Mesmo desenho vale para auth, trilhas, etc. **Vertical slice** = cada feature atravessa todas as camadas.
+
+---
+
+## 7. Tabela-resumo: conceitos Go ↔ lugar no código
+
+| Conceito Go | Onde aparece no projeto |
+|-------------|-------------------------|
+| Package + `internal/` | Toda a árvore `backend-platform` |
+| Struct + métodos | `Usuario`, `Artigo`, `Trilha` |
+| Embedding | `kernel.BaseEntity` |
+| Interface implícita | `TokenGerador`, `ArtigoRepository`, fakes nos testes |
+| Ponteiro vs valor | Receivers `*Artigo`, `*time.Time` opcional |
+| `error` + `errors.As` | `DomainError` nos handlers |
+| `context.Context` | Use cases e repos |
+| Middleware chain | Chi `r.Use(...)` |
+| Goroutine + channel | Graceful shutdown no `main` |
+| Table-driven / mocks | `*_test.go` + `mocks_test.go` |
+| `map[K]struct{}` | Allowlist CORS |
+| `json.RawMessage` | Conteúdo do artigo |
+| Transação (`Begin/Commit`) | Save de trilha + módulos |
+
+---
+
+## 8. Roteiro sugerido da aula (45–60 min)
+
+1. **5 min** — Problema de negócio e stack (Go + Postgres + Chi).
+2. **10 min** — Camadas DDD no filesystem; Dependency Rule.
+3. **10 min** — Auth Sprint 1: VO Email, ports, JWT, anti-enumeração.
+4. **5 min** — PR #5 e #7: consistência de sessão (persistir + logout).
+5. **5 min** — PR #6: middleware e CORS (browser).
+6. **10 min** — PR #8: aggregate Artigo, slug, JSONB, Forbidden.
+7. **10 min** — PR #9: aggregate com filhos, transação, invariantes.
+8. **5 min** — Exercício: “onde colocariam rate limit? e vínculo artigo–trilha?”
+
+---
+
+## 9. Exercícios para os alunos
+
+1. Onde a senha em texto puro **não** pode aparecer? (Resposta: domínio só vê `SenhaHash`; plain só no use case → port hasher.)
+2. Por que `ReconstruirUsuario` não valida de novo? (Dado já persistido; validação na escrita.)
+3. Implementar mentalmente: `DELETE /artigos/{id}` — em qual camada a regra “só autor ou admin”?
+4. No merge de #8+#9, o que quebra se esquecer de registrar rotas no `router`? (Compila, mas 404.)
+
+---
+
+## 10. O que ainda não está feito (honestidade na aula)
+
+- Vínculo `artigo.trilha_id` / `modulo_id`
+- Embeddings + `pgvector` (busca semântica)
+- Cookies HttpOnly (hoje tokens no JSON body)
+- Frontend Next.js
+- Rate limit em `/auth/*`
+- sqlc (README menciona; código usa `pgx` direto)
+
+Isso reforça: **documentação de arquitetura ≠ código entregue** — e está tudo bem no MVP, desde que o gap seja consciente.
+
+---
+
+## 11. Links rápidos dos PRs
+
+| PR | Título | URL |
+|----|--------|-----|
+| #5 | Persiste refresh no registro | https://github.com/Thiago-Tertuliano/MVP-Proj/pull/5 |
+| #6 | Middleware CORS | https://github.com/Thiago-Tertuliano/MVP-Proj/pull/6 |
+| #7 | Logout | https://github.com/Thiago-Tertuliano/MVP-Proj/pull/7 |
+| #8 | CRUD Artigos | https://github.com/Thiago-Tertuliano/MVP-Proj/pull/8 |
+| #9 | CRUD Trilhas/Módulos | https://github.com/Thiago-Tertuliano/MVP-Proj/pull/9 |
+
+---
+
+*Documento gerado para apoio à aula sobre o backend Go do Estudos Platform — Axellion / MVP Bruno & Thiago.*


### PR DESCRIPTION
## Summary
- Domínio `Trilha` + `Modulo` com regras de publicação
- Migration `0003_create_trilhas`
- Endpoints: `GET/POST /trilhas`, `GET /trilhas/{slug}`, `POST /trilhas/{id}/modulos`, `POST /trilhas/{id}/publicar`
- Collection Bruno (`estudos-platform/bruno`) para testar a API
- Material de aula: `docs/AULA-CODE-REVIEW-GO-SPRINT.md`

## Test plan
- [ ] `make migrate-up`
- [ ] `go test ./internal/... -count=1`
- [ ] Auth → criar trilha → adicionar módulo → publicar → listar/obter
- [ ] Abrir collection no Bruno e rodar Health + Login + fluxo de trilhas

## Nota
Merge após `feat/artigos-crud` (#8) se ambos forem aceitos: resolver conflito no `Makefile`/`router` unindo rotas e migrations 0002+0003.