### PR TITLE
ci: adiciona golangci-lint e valida titulo conventional do PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [dev]
+    types: [opened, edited, synchronize, reopened]
   push:
     branches: [dev]
   workflow_dispatch:
@@ -25,7 +26,6 @@ jobs:
           name=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]')
           echo "branch=$name"
 
-          # type/descricao — se falhar, o job de build nem começa
           if echo "$name" | grep -Eq '^(feat|fix|bug|ref|refactor|ci|docs|chore)/[a-z0-9._-]+$'; then
             echo "nome de branch válido"
             exit 0
@@ -36,6 +36,54 @@ jobs:
           echo "Tipos: feat/  fix/  bug/  ref/  ci/  docs/  chore/"
           echo "Exemplo: feat/vincular-artigo-trilha"
           exit 1
+
+      - name: Validate PR title
+        env:
+          EVENT: ${{ github.event_name }}
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "Não é PR — skip da validação de título"
+            exit 0
+          fi
+
+          echo "title=$TITLE"
+          # feat: texto  |  feat(escopo): texto  |  fix, bug, ref, ci, docs, chore
+          if echo "$TITLE" | grep -Eq '^(feat|fix|bug|ref|refactor|ci|docs|chore)(\([a-z0-9_-]+\))?: .+'; then
+            echo "título de PR válido"
+            exit 0
+          fi
+
+          echo "::error::Título de PR inválido: '$TITLE'"
+          echo "Use conventional commits: tipo: descrição"
+          echo "Tipos: feat:  fix:  bug:  ref:  ci:  docs:  chore:"
+          echo "Exemplo: feat: vincula artigo à trilha"
+          echo "Com escopo: feat(auth): persiste refresh no registro"
+          exit 1
+
+  lint:
+    name: lint
+    needs: branch-name
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: estudos-platform/backend-platform
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.1"
+          cache-dependency-path: estudos-platform/backend-platform/go.sum
+
+      - name: go vet
+        run: go vet ./...
+
+      - uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest
+          working-directory: estudos-platform/backend-platform
+          args: --timeout=5m
 
   test:
     name: test-coverage-build

--- a/estudos-platform/backend-platform/.golangci.yml
+++ b/estudos-platform/backend-platform/.golangci.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - unused

--- a/estudos-platform/backend-platform/README.md
+++ b/estudos-platform/backend-platform/README.md
@@ -4,6 +4,8 @@
 
 API monolítica modular em Go para a plataforma de estudos de TI. Segue **Domain-Driven Design (DDD)** estrito, **Vertical Slicing** por funcionalidade e **PostgreSQL + pgvector** para conteúdo dinâmico e busca semântica.
 
+PRs contra `dev`: branch `tipo/descricao` (`feat/`, `fix/`, `bug/`, `ref/`, `ci/`, `docs/`, `chore/`) e título conventional (`feat: …`, `fix(auth): …`). Sem isso o job `branch-name` falha e o build/lint não rodam.
+
 ---
 
 ## 📌 Stack

--- a/estudos-platform/backend-platform/internal/infrastructure/persistence/postgres/repository/trilha_repo_pg.go
+++ b/estudos-platform/backend-platform/internal/infrastructure/persistence/postgres/repository/trilha_repo_pg.go
@@ -27,7 +27,7 @@ func (r *TrilhaRepoPG) Save(ctx context.Context, t *entity.Trilha) error {
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback(ctx)
+	defer func() { _ = tx.Rollback(ctx) }()
 
 	_, err = tx.Exec(ctx, `
 		INSERT INTO trilhas (id, slug, titulo, descricao, capa_url, ordem, publicada, created_at, updated_at)


### PR DESCRIPTION
## Summary
- Job `lint`: `go vet` + `golangci-lint` (errcheck, govet, ineffassign, unused)
- Título do PR obrigatório no padrão conventional: `feat: …` / `fix(auth): …`
- `pull_request.types` inclui `edited` para revalidar se o título for corrigido
- Lint e testes rodam em paralelo depois do job `branch-name`

## Test plan
- [ ] `branch-name` verde (branch `ci/lint-and-pr-title` + título `ci: …`)
- [ ] `lint` verde
- [ ] `test-coverage-build` verde