### PR TITLE
feat: anotações e saves

### DIFF
--- a/estudos-platform/backend-platform/internal/applications/estudos/dto/anotacao_dto.go
+++ b/estudos-platform/backend-platform/internal/applications/estudos/dto/anotacao_dto.go
@@ -1,0 +1,13 @@
+package dto
+
+import "encoding/json"
+
+type SalvarAnotacaoRequest struct {
+	// Vou ajustar isso depois, mas aceita o JSON livre no frontend, então não precisa de validação por enquanto - =) Thigas
+	Conteudo json.RawMessage `json:"conteudo" validate:"required"`
+}
+
+type AnotacaoResponse struct {
+	ArtigoID string          `json:"artigo_id"`
+	Conteudo json.RawMessage `json:"conteudo"`
+}

--- a/estudos-platform/backend-platform/internal/applications/estudos/usecase/obter_anotacao.go
+++ b/estudos-platform/backend-platform/internal/applications/estudos/usecase/obter_anotacao.go
@@ -1,0 +1,44 @@
+package usecase
+
+import (
+	"context"
+	stderrors "errors"
+
+	"github.com/google/uuid"
+	"github.com/thiago-tertuliano/estudos-platform/internal/applications/estudos/dto"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/repository"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+type ObterAnotacao struct {
+	anotacoes repository.AnotacaoRepository
+}
+
+func NewObterAnotacao(anotacoes repository.AnotacaoRepository) *ObterAnotacao {
+	return &ObterAnotacao{
+		anotacoes: anotacoes,
+	}
+}
+
+func (uc *ObterAnotacao) Execute(ctx context.Context, usuarioID, artigoID string) (*dto.AnotacaoResponse, error) {
+	if _, err := uuid.Parse(usuarioID); err != nil {
+		return nil, errors.ErrInvalidArgument("usuario_id inválido", "ObterAnotacao.Execute", err)
+	}
+	if _, err := uuid.Parse(artigoID); err != nil {
+		return nil, errors.ErrInvalidArgument("artigo_id inválido", "ObterAnotacao.Execute", err)
+	}
+
+	a, err := uc.anotacoes.FindByUsuarioEArtigo(ctx, usuarioID, artigoID)
+	if err != nil {
+		var de *errors.DomainError
+		if stderrors.As(err, &de) {
+			return nil, err
+		}
+		return nil, errors.ErrInternal("falha ao buscar anotacao", "ObterAnotacao.Execute", err)
+	}
+
+	return &dto.AnotacaoResponse{
+		ArtigoID: a.ArtigoID,
+		Conteudo: a.Conteudo,
+	}, nil
+}

--- a/estudos-platform/backend-platform/internal/applications/estudos/usecase/salvar_anotacao.go
+++ b/estudos-platform/backend-platform/internal/applications/estudos/usecase/salvar_anotacao.go
@@ -1,0 +1,62 @@
+package usecase
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+
+	"github.com/google/uuid"
+	"github.com/thiago-tertuliano/estudos-platform/internal/applications/estudos/dto"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/repository"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+type SalvarAnotacaoUseCase struct {
+	artigos repository.ArtigoRepository
+	anotacoes repository.AnotacaoRepository
+}
+
+func NewSalvarAnotacao(artigos repository.ArtigoRepository, anotacoes repository.AnotacaoRepository) *SalvarAnotacaoUseCase {
+	return &SalvarAnotacaoUseCase{
+		artigos: artigos,
+		anotacoes: anotacoes,
+	}
+}
+
+func (uc *SalvarAnotacaoUseCase) Execute(ctx context.Context, usuarioID, artigoID string, request dto.SalvarAnotacaoRequest) (*dto.AnotacaoResponse, error) {
+	if _, err := uuid.Parse(usuarioID); err != nil {
+		return nil, errors.ErrInvalidArgument("usuario_id inválido", "SalvarAnotacaoUseCase.Execute", err)
+	}
+	if _, err := uuid.Parse(artigoID); err != nil {
+		return nil, errors.ErrInvalidArgument("artigo_id inválido", "SalvarAnotacaoUseCase.Execute", err)
+	}
+	if len(request.Conteudo) == 0 || !json.Valid(request.Conteudo) {
+		return nil, errors.ErrInvalidArgument("conteudo JSON inválido", "SalvarAnotacaoUseCase.Execute", nil)
+	}
+
+	if _, err := uc.artigos.FindByID(ctx, artigoID); err != nil {
+		var de *errors.DomainError
+		if stderrors.As(err, &de) {
+			return nil, err
+		}
+		return nil, errors.ErrInternal("falha ao buscar", "SalvarAnotacaoUseCase.Execute", err)
+	}
+
+	a := repository.Anotacao{
+		UsuarioID: usuarioID,
+		ArtigoID:  artigoID,
+		Conteudo:  request.Conteudo,
+	}
+	if err := uc.anotacoes.Upsert(ctx, a); err != nil {
+		var de *errors.DomainError
+		if stderrors.As(err, &de) {
+			return nil, err
+		}
+		return nil, errors.ErrInternal("falha ao salvar anotacao", "SalvarAnotacaoUseCase.Execute", err)
+	}
+
+	return &dto.AnotacaoResponse{
+		ArtigoID: artigoID,
+		Conteudo: request.Conteudo,
+	}, nil
+}

--- a/estudos-platform/backend-platform/internal/applications/estudos/usecase/salvar_anotacao_test.go
+++ b/estudos-platform/backend-platform/internal/applications/estudos/usecase/salvar_anotacao_test.go
@@ -1,0 +1,93 @@
+package usecase
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/thiago-tertuliano/estudos-platform/internal/applications/estudos/dto"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/entity"
+	"github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/repository"
+	domainErros "github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+type mockAnotacaoRepo struct {
+	UpsertFn func(ctx context.Context, a repository.Anotacao) error
+	FindFn   func(ctx context.Context, usuarioID, artigoID string) (*repository.Anotacao, error)
+}
+
+func (m *mockAnotacaoRepo) Upsert(ctx context.Context, a repository.Anotacao) error {
+	return m.UpsertFn(ctx, a)
+}
+
+func (m *mockAnotacaoRepo) FindByUsuarioEArtigo(ctx context.Context, usuarioID, artigoID string) (*repository.Anotacao, error) {
+	if m.FindFn != nil {
+		return m.FindFn(ctx, usuarioID, artigoID)
+	}
+	return &repository.Anotacao{UsuarioID: usuarioID, ArtigoID: artigoID, Conteudo: json.RawMessage(`{}`)}, nil
+}
+
+func TestSalvarAnotacao_Sucesso(t *testing.T) {
+	artigoID := uuid.New().String()
+	userID := uuid.New().String()
+	var saved repository.Anotacao
+
+	uc := NewSalvarAnotacao(
+		&MockArtigoRepository{
+			FindByIDFn: func(ctx context.Context, id string) (*entity.Artigo, error) {
+				return &entity.Artigo{}, nil
+			},
+		},
+		&mockAnotacaoRepo{
+			UpsertFn: func(ctx context.Context, a repository.Anotacao) error {
+				saved = a
+				return nil
+			},
+		},
+	)
+
+	conteudo := json.RawMessage(`{"notes":[{"texto":"lembrar do aggregate"}]}`)
+	resp, err := uc.Execute(context.Background(), userID, artigoID, dto.SalvarAnotacaoRequest{Conteudo: conteudo})
+	if err != nil {
+		t.Fatalf("inesperado: %v", err)
+	}
+	if resp.ArtigoID != artigoID {
+		t.Fatalf("resp: %+v", resp)
+	}
+	if saved.UsuarioID != userID || saved.ArtigoID != artigoID {
+		t.Fatalf("upsert: %+v", saved)
+	}
+}
+
+func TestSalvarAnotacao_ArtigoInexistente(t *testing.T) {
+	uc := NewSalvarAnotacao(
+		&MockArtigoRepository{
+			FindByIDFn: func(ctx context.Context, id string) (*entity.Artigo, error) {
+				return nil, domainErros.ErrNotFound("artigo não encontrado", "test", nil)
+			},
+		},
+		&mockAnotacaoRepo{
+			UpsertFn: func(ctx context.Context, a repository.Anotacao) error {
+				t.Fatal("não deveria upsertar")
+				return nil
+			},
+		},
+	)
+	_, err := uc.Execute(context.Background(), uuid.New().String(), uuid.New().String(), dto.SalvarAnotacaoRequest{
+		Conteudo: json.RawMessage(`{"notes":[]}`),
+	})
+	if de, ok := err.(*domainErros.DomainError); !ok || de.Kind != domainErros.NotFound {
+		t.Fatalf("esperava NotFound, got %#v", err)
+	}
+}
+
+func TestSalvarAnotacao_JSONInvalido(t *testing.T) {
+	uc := NewSalvarAnotacao(&MockArtigoRepository{}, &mockAnotacaoRepo{})
+	_, err := uc.Execute(context.Background(), uuid.New().String(), uuid.New().String(), dto.SalvarAnotacaoRequest{
+		Conteudo: json.RawMessage(`{quebrado`),
+	})
+	if de, ok := err.(*domainErros.DomainError); !ok || de.Kind != domainErros.InvalidArgument {
+		t.Fatalf("esperava InvalidArgument, got %#v", err)
+	}
+}

--- a/estudos-platform/backend-platform/internal/domain/estudos/repository/anotacao_repository.go
+++ b/estudos-platform/backend-platform/internal/domain/estudos/repository/anotacao_repository.go
@@ -1,0 +1,17 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type Anotacao struct {
+	UsuarioID string 
+	ArtigoID  string
+	Conteudo  json.RawMessage
+}
+
+type AnotacaoRepository interface {
+	Upsert(ctx context.Context, a Anotacao) error
+	FindByUsuarioEArtigo(ctx context.Context, usuarioID, artigoID string) (*Anotacao, error)
+}

--- a/estudos-platform/backend-platform/internal/infrastructure/persistence/postgres/migration/0008_create_anotacoes.down.sql
+++ b/estudos-platform/backend-platform/internal/infrastructure/persistence/postgres/migration/0008_create_anotacoes.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS anotacoes;

--- a/estudos-platform/backend-platform/internal/infrastructure/persistence/postgres/migration/0008_create_anotacoes.up.sql
+++ b/estudos-platform/backend-platform/internal/infrastructure/persistence/postgres/migration/0008_create_anotacoes.up.sql
@@ -1,0 +1,12 @@
+
+CREATE TABLE IF NOT EXISTS anotacoes (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      usuario_id UUID NOT NULL REFERENCES usuarios(id) ON DELETE CASCADE,
+      artigo_id UUID NOT NULL REFERENCES artigos(id) ON DELETE CASCADE,
+      conteudo JSONB NOT NULL DEFAULT '{}',
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      UNIQUE (usuario_id, artigo_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_anotacoes_artigo ON anotacoes(artigo_id);

--- a/estudos-platform/backend-platform/internal/infrastructure/persistence/postgres/repository/anotacao_repo_pg.go
+++ b/estudos-platform/backend-platform/internal/infrastructure/persistence/postgres/repository/anotacao_repo_pg.go
@@ -1,0 +1,70 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	domrepo "github.com/thiago-tertuliano/estudos-platform/internal/domain/estudos/repository"
+	domainErros "github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+)
+
+type AnotacaoRepoPG struct {
+	pool *pgxpool.Pool
+}
+
+func NewAnotacaoRepoPG(pool *pgxpool.Pool) *AnotacaoRepoPG {
+	return &AnotacaoRepoPG{pool: pool}
+}
+
+func (r *AnotacaoRepoPG) Upsert(ctx context.Context, a domrepo.Anotacao) error {
+	conteudo := a.Conteudo
+	if len(conteudo) == 0 {
+		conteudo = json.RawMessage("{}")
+	}
+
+	_, err := r.pool.Exec(ctx, `
+		INSERT INTO anotacoes (id, usuario_id, artigo_id, conteudo, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, NOW(), NOW())
+		ON CONFLICT (usuario_id, artigo_id) DO UPDATE SET
+			conteudo = EXCLUDED.conteudo,
+			updated_at = NOW()
+	`, uuid.New().String(), a.UsuarioID, a.ArtigoID, conteudo)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgForeignKey {
+			return domainErros.ErrNotFound("artigo ou usuário nao encontrado", "anotacao_repo_pg.Upsert", nil)
+		}
+		return MapPG(err, "anotacao_repo_pg.Upsert")
+	}
+	return nil
+}
+
+func (r *AnotacaoRepoPG) FindByUsuarioEArtigo(ctx context.Context, usuarioID, artigoID string) (*domrepo.Anotacao, error) {
+	var conteudo []byte
+	err := r.pool.QueryRow(ctx, `
+		SELECT conteudo
+		FROM anotacoes
+		WHERE usuario_id = $1 AND artigo_id = $2
+	`, usuarioID, artigoID).Scan(&conteudo)
+	if err !=  nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Front recebe vazio em vez de 404 na primeira visita
+			return &domrepo.Anotacao{
+				UsuarioID: usuarioID,
+				ArtigoID:  artigoID,
+				Conteudo:  json.RawMessage("{}"),
+			}, nil
+		}
+		return nil, MapPG(err, "anotacao_repo_pg.FindByUsuarioEArtigo")
+	}
+	return &domrepo.Anotacao{
+		UsuarioID: usuarioID,
+		ArtigoID:  artigoID,
+		Conteudo:  json.RawMessage(conteudo),
+	}, nil
+}

--- a/estudos-platform/backend-platform/internal/presentation/http/handler/anotacao_handler.go
+++ b/estudos-platform/backend-platform/internal/presentation/http/handler/anotacao_handler.go
@@ -1,0 +1,92 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"errors"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-playground/validator/v10"
+	"github.com/thiago-tertuliano/estudos-platform/internal/applications/estudos/dto"
+	domainErros "github.com/thiago-tertuliano/estudos-platform/internal/domain/shared/errors"
+	"github.com/thiago-tertuliano/estudos-platform/internal/presentation/http/middleware"
+)
+
+type SalvarAnotacaoUseCase interface {
+	Execute(ctx context.Context, usuarioID, artigoID string, req dto.SalvarAnotacaoRequest) (*dto.AnotacaoResponse, error)
+}
+
+type ObterAnotacaoUseCase interface {
+	Execute(ctx context.Context, usuarioID, artigoID string) (*dto.AnotacaoResponse, error)
+}
+
+type AnotacaoHandler struct {
+	salvar SalvarAnotacaoUseCase
+	obter ObterAnotacaoUseCase
+	validate *validator.Validate
+}
+
+func NewAnotacaoHandler(salvar SalvarAnotacaoUseCase, obter ObterAnotacaoUseCase) *AnotacaoHandler {
+	return &AnotacaoHandler{
+		salvar: salvar,
+		obter: obter,
+		validate: validator.New(),
+	}
+}
+
+func (h *AnotacaoHandler) Salvar(w http.ResponseWriter, r *http.Request) {
+	var req dto.SalvarAnotacaoRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.escreverJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if err := h.validate.Struct(req); err != nil {
+		h.escreverJSON(w, http.StatusBadRequest, map[string]string{"error": "validation failed"})
+		return
+	}
+
+	usuarioID, _ := r.Context().Value(middleware.CtxUsuarioID).(string)
+	artigoID := chi.URLParam(r, "id")
+
+	resp, err := h.salvar.Execute(r.Context(), usuarioID, artigoID, req)
+	if err != nil {
+		h.escreverErro(w, err)
+		return
+	}
+	h.escreverJSON(w, http.StatusOK, resp)
+}
+
+func (h *AnotacaoHandler) Obter(w http.ResponseWriter, r *http.Request) {
+	usuarioID, _ := r.Context().Value(middleware.CtxUsuarioID).(string)
+	artigoID := chi.URLParam(r, "id")
+	resp, err := h.obter.Execute(r.Context(), usuarioID, artigoID)
+	if err != nil {
+		h.escreverErro(w, err)
+		return
+	}
+	h.escreverJSON(w, http.StatusOK, resp)
+}
+
+func (h *AnotacaoHandler) escreverJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+func (h *AnotacaoHandler) escreverErro(w http.ResponseWriter, err error) {
+	var de *domainErros.DomainError
+	if !errors.As(err, &de) {
+		h.escreverJSON(w, http.StatusInternalServerError, map[string]string{"erro": "erro interno"})
+		return
+	}
+	status := http.StatusInternalServerError
+	switch de.Kind {
+	case domainErros.InvalidArgument:
+		status = http.StatusBadRequest
+	case domainErros.NotFound:
+		status = http.StatusNotFound
+	case domainErros.InvalidState:
+		status = http.StatusConflict
+	}
+	h.escreverJSON(w, status, map[string]string{"erro": de.Message})
+}

--- a/estudos-platform/backend-platform/internal/presentation/http/router/router.go
+++ b/estudos-platform/backend-platform/internal/presentation/http/router/router.go
@@ -31,6 +31,7 @@ func New(cfg *config.Config, pool *pgxpool.Pool) http.Handler {
 	artigoRepo := pgrepo.NewArtigoRepoPG(pool)
 	trilhaRepo := pgrepo.NewTrilhaRepoPG(pool)
 	progressoRepo := pgrepo.NewProgressoRepoPG(pool)
+	anotacaoRepo := pgrepo.NewAnotacaoRepoPG(pool)
 
 	hasher := external.NewBcryptHasher(10)
 	tokens := external.NewJWTService(cfg.JWTSecret)
@@ -63,6 +64,8 @@ func New(cfg *config.Config, pool *pgxpool.Pool) http.Handler {
 	marcarLidoUC := usecase.NewMarcarArtigoLido(artigoRepo, progressoRepo)
 	progressoTrilhaUC := usecase.NewObterProgressoTrilha(progressoRepo)
 	buscarUC := usecase.NewBuscarArtigos(artigoRepo)
+	salvarAnotacaoUC := usecase.NewSalvarAnotacao(artigoRepo, anotacaoRepo)
+	obterAnotacaoUC := usecase.NewObterAnotacao(anotacaoRepo)
 
 	auth := handler.NewAuthHandler(registrarUC, loginUC, refreshUC, perfilUC, logoutUC, handler.AuthCookies{
 		AccessMaxAge:  cfg.JWTAccessTTLMin * 60,
@@ -73,7 +76,7 @@ func New(cfg *config.Config, pool *pgxpool.Pool) http.Handler {
 	trilhas := handler.NewTrilhaHandler(criarTrilhaUC, obterTrilhaUC, listarTrilhasUC, adicionarModuloUC, publicarTrilhaUC, )
 	progresso := handler.NewProgressoHandler(marcarLidoUC, progressoTrilhaUC)
 	busca := handler.NewBuscaHandler(buscarUC)
-
+	anotacoes := handler.NewAnotacaoHandler(salvarAnotacaoUC, obterAnotacaoUC)
 	r.Route("/api/v1", func(api chi.Router) {
 		limiteAuth := middleware.NewRateLimit(10, time.Minute)
 		api.Group(func(pub chi.Router) {
@@ -102,6 +105,8 @@ func New(cfg *config.Config, pool *pgxpool.Pool) http.Handler {
 			pr.Post("/trilhas/{id}/publicar", trilhas.Publicar)
 			pr.Put("/progresso/artigos/{id}", progresso.MarcarArtigo)
 			pr.Get("/progresso/trilhas/{id}", progresso.ObterTrilha)
+			pr.Put("/artigos/{id}/anotacoes", anotacoes.Salvar)
+			pr.Get("/artigos/{id}/anotacoes", anotacoes.Obter)
 		})
 	})
 


### PR DESCRIPTION
## Summary
- Adiciona anotações do aluno por artigo (`UNIQUE usuario_id + artigo_id`) com conteúdo JSONB flexível (`notes`, `highlights`, `bookmarks`).
- Expõe `PUT` e `GET` autenticados em `/api/v1/artigos/{id}/anotacoes` (migration `0008`, repo, use cases, handler e wiring no router).
- Inclui testes do use case `SalvarAnotacao` (sucesso, artigo inexistente, JSON inválido).

## Endpoints
- `PUT /api/v1/artigos/{id}/anotacoes` — upsert da anotação do usuário logado
- `GET /api/v1/artigos/{id}/anotacoes` — retorna anotação ou `conteudo: {}` se ainda não existir

## Test plan
- [ ] Rodar migration `0008` (`migrate-up`)
- [ ] `go test ./internal/applications/estudos/usecase/ -run Anotacao`
- [ ] `go build ./cmd/api`
- [ ] Login → criar/usar um `artigoId` → `PUT .../anotacoes` com body de `conteudo` → `200`
- [ ] `GET .../anotacoes` → mesmo conteúdo salvo
- [ ] `GET` sem anotação prévia → `200` com `conteudo: {}`
- [ ] Sem Bearer → `401`