### PR TITLE
ci: docs & ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,14 @@ jobs:
           name=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]')
           echo "branch=$name"
 
-          if echo "$name" | grep -Eq '^(feat|fix|bug|ref|refactor|ci|docs|chore)/[a-z0-9._-]+$'; then
+          if echo "$name" | grep -Eq '^(feat|feature|hotfix|fix|bugfix|bug|ref|refactor|ci|docs|chore)/[a-z0-9._-]+$'; then
             echo "nome de branch válido"
             exit 0
           fi
 
           echo "::error::Branch inválida: '$BRANCH'"
           echo "Use: type/descricao-em-kebab-case"
-          echo "Tipos: feat/  fix/  bug/  ref/  ci/  docs/  chore/"
+          echo "Tipos: feat/  feature/  hotfix/  fix/  bugfix/  bug/  ref/  refactor/  ci/  docs/  chore/"
           echo "Exemplo: feat/vincular-artigo-trilha"
           exit 1
 
@@ -49,7 +49,7 @@ jobs:
 
           echo "title=$TITLE"
           # feat: texto  |  feat(escopo): texto  |  fix, bug, ref, ci, docs, chore
-          if echo "$TITLE" | grep -Eq '^(feat|fix|bug|ref|refactor|ci|docs|chore)(\([a-z0-9_-]+\))?: .+'; then
+          if echo "$TITLE" | grep -Eq '^(feat|feature|hotfix|fix|bugfix|bug|ref|refactor|ci|docs|chore)(\([a-z0-9_-]+\))?: .+'; then
             echo "título de PR válido"
             exit 0
           fi

--- a/estudos-platform/bruno/03-artigos/06-salvar-anotacao.bru
+++ b/estudos-platform/bruno/03-artigos/06-salvar-anotacao.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Salvar Anotacao
+  type: http
+  seq: 6
+}
+
+put {
+  url: {{baseUrl}}/api/v1/artigos/{{artigoId}}/anotacoes
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "conteudo": {
+      "notes": [
+        { "texto": "Relembrar Aggregate Root" }
+      ],
+      "highlights": [],
+      "bookmarks": []
+    }
+  }
+}
+
+assert {
+  res.status: eq 200
+}

--- a/estudos-platform/bruno/03-artigos/07-obter-anotacao.bru
+++ b/estudos-platform/bruno/03-artigos/07-obter-anotacao.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Obter Anotacao
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{baseUrl}}/api/v1/artigos/{{artigoId}}/anotacoes
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{accessToken}}
+}
+
+assert {
+  res.status: eq 200
+}


### PR DESCRIPTION
## Summary
- Amplia a validação do CI para aceitar prefixos `feature/`, `hotfix/` e `bugfix/` em nome de branch e título de PR (além dos já existentes).
- Adiciona requests Bruno para o fluxo de anotações: `PUT` e `GET` em `/api/v1/artigos/{id}/anotacoes`.

## Test plan
- [ ] Abrir PR com branch `feature/...` ou título `feature: ...` e confirmar que o job `branch-name` passa
- [ ] Confirmar que `feat/...` e `fix:...` continuam válidos
- [ ] No Bruno: Login → preencher `artigoId` → rodar `06-salvar-anotacao` → `07-obter-anotacao` → `200`